### PR TITLE
Add id slug field to metadata

### DIFF
--- a/formatters/sort_frontmatter.py
+++ b/formatters/sort_frontmatter.py
@@ -122,6 +122,7 @@ def sort_frontmatter_properties(frontmatter_content: str) -> str:
     """
     # Definiera den önskade ordningen för properties
     PROPERTY_ORDER = [
+        'id',
         'beteckning',
         'rubrik',
         'normtyp',


### PR DESCRIPTION
## Summary
- Adds a new `id` field at the top of the YAML frontmatter in all documents
- The `id` is generated from `beteckningSortable` in the format `sfs-YYYY-NNN` (e.g., `sfs-2024-1000`)
- Refactors filename generation to use the id slug (filenames remain unchanged: `sfs-2024-1000.md`)
- Updates frontmatter sorting to ensure `id` appears first

## Changes
- **`sfs_processor.py`**: 
  - New `create_id_slug()` function to generate clean slug from `beteckningSortable`
  - Updated `create_safe_filename()` to use id slug as input (filenames unchanged)
  - Modified frontmatter generation to include `id` field at the top
  - The `id` field value matches the filename (without .md extension)
- **`formatters/sort_frontmatter.py`**: 
  - Added `id` to `PROPERTY_ORDER` as the first field

## Example
```yaml
---
id: sfs-2010-800
beteckning: "2010:800"
rubrik: Skollag
normtyp: Lag
...
---
```

Filename: `sfs-2010-800.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)