### PR TITLE
Fix: Resolve git checkout error in fetch-sfs-workflow

### DIFF
--- a/.github/workflows/fetch-sfs-workflow.yml
+++ b/.github/workflows/fetch-sfs-workflow.yml
@@ -88,9 +88,9 @@ jobs:
         # Get current branch
         CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
-        # Create a new branch for commits if we have changes
-        git add data/md-markers/ data/sfs_json/
-        if git diff --staged --quiet; then
+        # Check if we have changes (without staging yet)
+        if git diff --quiet data/md-markers/ data/sfs_json/ && \
+           ! git ls-files --others --exclude-standard data/md-markers/ data/sfs_json/ | grep -q .; then
           echo "Inga nya filer att committa"
           echo "has_changes=false" >> $GITHUB_OUTPUT
         else
@@ -110,6 +110,9 @@ jobs:
             # Branch doesn't exist - create new
             git checkout -b "$COMMIT_BRANCH"
           fi
+
+          # Now add files after we're on the correct branch
+          git add data/md-markers/ data/sfs_json/
 
           # Commit with multi-line message
           git commit -m "Automatisk uppdatering av SFS-författningar $(date +'%Y-%m-%d')" \


### PR DESCRIPTION
## Problem
The `fetch-sfs-workflow` was failing with this error:
```
error: Your local changes to the following files would be overwritten by checkout:
	data/md-markers/...
Aborting
```

## Root Cause
The workflow was staging changes with `git add` **before** attempting to checkout the target branch. When the branch existed remotely, `git checkout` would fail because it would overwrite the staged changes.

## Solution
This PR fixes the issue by:
1. Checking for changes **without** staging them first (using `git diff --quiet` and `git ls-files --others`)
2. Checking out the target branch **before** running `git add`
3. Staging files only after being on the correct branch

## Testing
The workflow should now successfully:
- Check for changes in `data/md-markers/` and `data/sfs_json/`
- Checkout existing `workflow-artifact-data` branch without conflicts
- Stage and commit changes on the correct branch

## Related
Fixes the error seen in: https://github.com/se-lex/sfs-processor/actions/runs/20804696587/job/59756444556

🤖 Generated with [Claude Code](https://claude.com/claude-code)