### PR TITLE
Förbättra registret med lagnamn

### DIFF
--- a/data/law-names.json
+++ b/data/law-names.json
@@ -469,7 +469,7 @@
   },
   {
     "id": "1974:371",
-    "name": "",
+    "name": "lagen om rättegången i arbetstvister",
     "type": "law",
     "alternativeNames": [
       "LRA"
@@ -526,7 +526,7 @@
   },
   {
     "id": "1976:580",
-    "name": "",
+    "name": "medbestämmandelagen",
     "type": "law",
     "alternativeNames": [
       "MBL"
@@ -635,7 +635,7 @@
   },
   {
     "id": "1980:100",
-    "name": "",
+    "name": "sekretesslagen",
     "type": "law",
     "alternativeNames": [
       "SekrL"
@@ -649,7 +649,7 @@
   },
   {
     "id": "1980:657",
-    "name": "",
+    "name": "sekretessförordningen",
     "type": "law",
     "alternativeNames": [
       "SekrF"
@@ -673,7 +673,7 @@
   },
   {
     "id": "1981:981",
-    "name": "",
+    "name": "utsökningsförordningen",
     "type": "law",
     "alternativeNames": [
       "UF"
@@ -755,7 +755,7 @@
   },
   {
     "id": "1985:206",
-    "name": "",
+    "name": "viteslagen",
     "type": "law",
     "alternativeNames": [
       "VitesL"
@@ -811,7 +811,7 @@
   },
   {
     "id": "1987:822",
-    "name": "",
+    "name": "lagen om internationella köp",
     "type": "law",
     "alternativeNames": [
       "CISG"
@@ -839,7 +839,7 @@
   },
   {
     "id": "1988:870",
-    "name": "",
+    "name": "lagen om vård av missbrukare i vissa fall",
     "type": "law",
     "alternativeNames": [
       "LVM"
@@ -867,7 +867,7 @@
   },
   {
     "id": "1990:52",
-    "name": "",
+    "name": "lagen med särskilda bestämmelser om vård av unga",
     "type": "law",
     "alternativeNames": [
       "LVU"
@@ -875,7 +875,7 @@
   },
   {
     "id": "1990:746",
-    "name": "",
+    "name": "lagen om betalningsföreläggande och handräckning",
     "type": "law",
     "alternativeNames": [
       "LBH"
@@ -909,7 +909,7 @@
   },
   {
     "id": "1991:1128",
-    "name": "",
+    "name": "lagen om psykiatrisk tvångsvård",
     "type": "law",
     "alternativeNames": [
       "LPT"
@@ -917,7 +917,7 @@
   },
   {
     "id": "1991:1129",
-    "name": "",
+    "name": "lagen om rättspsykiatrisk vård",
     "type": "law",
     "alternativeNames": [
       "LRV"
@@ -947,7 +947,7 @@
   },
   {
     "id": "1991:586",
-    "name": "",
+    "name": "lagen om särskild inkomstskatt för utomlands bosatta",
     "type": "law",
     "alternativeNames": [
       "SINK"
@@ -1000,7 +1000,7 @@
   },
   {
     "id": "1992:1685",
-    "name": "",
+    "name": "kulturmiljölagen",
     "type": "law",
     "alternativeNames": [
       "KML"
@@ -1044,7 +1044,7 @@
   },
   {
     "id": "1993:387",
-    "name": "",
+    "name": "lagen om stöd och service till vissa funktionshindrade",
     "type": "law",
     "alternativeNames": [
       "LSS"
@@ -1102,7 +1102,7 @@
   },
   {
     "id": "1994:260",
-    "name": "",
+    "name": "lagen om offentlig anställning",
     "type": "law",
     "alternativeNames": [
       "LOA"
@@ -1392,7 +1392,7 @@
   },
   {
     "id": "2001:1227",
-    "name": "",
+    "name": "lagen om självdeklarationer och kontrolluppgifter",
     "type": "law",
     "alternativeNames": [
       "LSK"
@@ -1450,7 +1450,7 @@
   },
   {
     "id": "2003:389",
-    "name": "",
+    "name": "lagen om elektronisk kommunikation",
     "type": "law",
     "alternativeNames": [
       "LEK"
@@ -1458,7 +1458,7 @@
   },
   {
     "id": "2003:778",
-    "name": "",
+    "name": "lagen om skydd mot olyckor",
     "type": "law",
     "alternativeNames": [
       "LSO"
@@ -1715,7 +1715,7 @@
   },
   {
     "id": "2013:561",
-    "name": "",
+    "name": "lagen om förvaltare av alternativa investeringsfonder",
     "type": "law",
     "alternativeNames": [
       "LAIF"
@@ -1730,7 +1730,7 @@
   },
   {
     "id": "2016:1145",
-    "name": "",
+    "name": "lagen om offentlig upphandling",
     "type": "law",
     "alternativeNames": [
       "LOU"
@@ -1738,7 +1738,7 @@
   },
   {
     "id": "2017:30",
-    "name": "",
+    "name": "hälso- och sjukvårdslagen",
     "type": "law",
     "alternativeNames": [
       "HSL"

--- a/data/law-names.json
+++ b/data/law-names.json
@@ -211,7 +211,9 @@
     "id": "1967:837",
     "name": "patentlagen",
     "type": "law",
-    "alternativeNames": [],
+    "alternativeNames": [
+      "PatL"
+    ],
     "category": "Immaterialrätt"
   },
   {
@@ -510,7 +512,9 @@
     "id": "1975:635",
     "name": "räntelagen",
     "type": "law",
-    "alternativeNames": []
+    "alternativeNames": [
+      "RänteL"
+    ]
   },
   {
     "id": "1976:19",
@@ -542,7 +546,9 @@
     "id": "1977:1160",
     "name": "arbetsmiljölagen",
     "type": "law",
-    "alternativeNames": [],
+    "alternativeNames": [
+      "AML"
+    ],
     "category": "Arbetsrätt"
   },
   {
@@ -659,7 +665,9 @@
     "id": "1981:130",
     "name": "preskriptionslagen",
     "type": "law",
-    "alternativeNames": [],
+    "alternativeNames": [
+      "PreskL"
+    ],
     "category": "Fordringsrätt"
   },
   {
@@ -689,7 +697,9 @@
     "id": "1982:673",
     "name": "arbetstidslagen",
     "type": "law",
-    "alternativeNames": [],
+    "alternativeNames": [
+      "ATL"
+    ],
     "category": "Arbetsrätt"
   },
   {
@@ -834,7 +844,9 @@
     "id": "1988:534",
     "name": "djurskyddslagen",
     "type": "law",
-    "alternativeNames": [],
+    "alternativeNames": [
+      "DjurskL"
+    ],
     "category": "Speciell förvaltningsrätt"
   },
   {
@@ -1193,13 +1205,17 @@
     "id": "1996:627",
     "name": "säkerhetsskyddslagen",
     "type": "law",
-    "alternativeNames": []
+    "alternativeNames": [
+      "SäkL"
+    ]
   },
   {
     "id": "1996:67",
     "name": "vapenlagen",
     "type": "law",
-    "alternativeNames": []
+    "alternativeNames": [
+      "VapenL"
+    ]
   },
   {
     "id": "1996:799",
@@ -1603,7 +1619,9 @@
     "id": "2008:567",
     "name": "diskrimineringslagen",
     "type": "law",
-    "alternativeNames": []
+    "alternativeNames": [
+      "DL"
+    ]
   },
   {
     "id": "2008:579",

--- a/data/law-names.json
+++ b/data/law-names.json
@@ -461,7 +461,8 @@
     "id": "1974:182",
     "name": "inkassolagen",
     "type": "law",
-    "alternativeNames": []
+    "alternativeNames": [],
+    "category": "Fordringsrätt"
   },
   {
     "id": "1974:211",
@@ -475,7 +476,8 @@
     "type": "law",
     "alternativeNames": [
       "LRA"
-    ]
+    ],
+    "category": "Arbetsrätt"
   },
   {
     "id": "1974:595",
@@ -514,7 +516,8 @@
     "type": "law",
     "alternativeNames": [
       "RänteL"
-    ]
+    ],
+    "category": "Fordringsrätt"
   },
   {
     "id": "1976:19",
@@ -534,7 +537,8 @@
     "type": "law",
     "alternativeNames": [
       "MBL"
-    ]
+    ],
+    "category": "Arbetsrätt"
   },
   {
     "id": "1976:633",
@@ -581,7 +585,8 @@
     "id": "1978:302",
     "name": "passlagen",
     "type": "law",
-    "alternativeNames": []
+    "alternativeNames": [],
+    "category": "Speciell förvaltningsrätt"
   },
   {
     "id": "1978:304",
@@ -691,7 +696,8 @@
     "id": "1982:670",
     "name": "namnlagen",
     "type": "law",
-    "alternativeNames": []
+    "alternativeNames": [],
+    "category": "Familjerätt"
   },
   {
     "id": "1982:673",
@@ -801,7 +807,8 @@
     "id": "1987:259",
     "name": "jaktlagen",
     "type": "law",
-    "alternativeNames": []
+    "alternativeNames": [],
+    "category": "Speciell förvaltningsrätt"
   },
   {
     "id": "1987:619",
@@ -838,7 +845,8 @@
     "id": "1988:254",
     "name": "knivlagen",
     "type": "law",
-    "alternativeNames": []
+    "alternativeNames": [],
+    "category": "Straffrätt"
   },
   {
     "id": "1988:534",
@@ -867,7 +875,8 @@
     "id": "1990:1144",
     "name": "begravningslagen",
     "type": "law",
-    "alternativeNames": []
+    "alternativeNames": [],
+    "category": "Speciell förvaltningsrätt"
   },
   {
     "id": "1990:324",
@@ -875,7 +884,8 @@
     "type": "law",
     "alternativeNames": [
       "TaxL"
-    ]
+    ],
+    "category": "Skatterätt"
   },
   {
     "id": "1990:52",
@@ -899,7 +909,8 @@
     "type": "law",
     "alternativeNames": [
       "ArkivL"
-    ]
+    ],
+    "category": "Allmän förvaltningsrätt"
   },
   {
     "id": "1990:931",
@@ -948,7 +959,8 @@
     "id": "1991:45",
     "name": "minerallagen",
     "type": "law",
-    "alternativeNames": []
+    "alternativeNames": [],
+    "category": "Speciell förvaltningsrätt"
   },
   {
     "id": "1991:481",
@@ -994,7 +1006,8 @@
     "id": "1992:1433",
     "name": "sametingslagen",
     "type": "law",
-    "alternativeNames": []
+    "alternativeNames": [],
+    "category": "Statsrätt"
   },
   {
     "id": "1992:1434",
@@ -1066,13 +1079,15 @@
     "id": "1993:581",
     "name": "tobakslagen",
     "type": "law",
-    "alternativeNames": []
+    "alternativeNames": [],
+    "category": "Speciell förvaltningsrätt"
   },
   {
     "id": "1993:787",
     "name": "fiskelagen",
     "type": "law",
-    "alternativeNames": []
+    "alternativeNames": [],
+    "category": "Speciell förvaltningsrätt"
   },
   {
     "id": "1994:1000",
@@ -1086,7 +1101,8 @@
     "type": "law",
     "alternativeNames": [
       "SjöL"
-    ]
+    ],
+    "category": "Speciell avtalsrätt"
   },
   {
     "id": "1994:1220",
@@ -1193,13 +1209,15 @@
     "id": "1996:1596",
     "name": "bibliotekslagen",
     "type": "law",
-    "alternativeNames": []
+    "alternativeNames": [],
+    "category": "Speciell förvaltningsrätt"
   },
   {
     "id": "1996:1619",
     "name": "rättshjälpslagen",
     "type": "law",
-    "alternativeNames": []
+    "alternativeNames": [],
+    "category": "Processrätt"
   },
   {
     "id": "1996:627",
@@ -1207,7 +1225,8 @@
     "type": "law",
     "alternativeNames": [
       "SäkL"
-    ]
+    ],
+    "category": "Speciell förvaltningsrätt"
   },
   {
     "id": "1996:67",
@@ -1215,7 +1234,8 @@
     "type": "law",
     "alternativeNames": [
       "VapenL"
-    ]
+    ],
+    "category": "Speciell förvaltningsrätt"
   },
   {
     "id": "1996:799",
@@ -1335,7 +1355,8 @@
     "id": "1999:1079",
     "name": "revisionslagen",
     "type": "law",
-    "alternativeNames": []
+    "alternativeNames": [],
+    "category": "Associationsrätt"
   },
   {
     "id": "1999:1229",
@@ -1357,7 +1378,8 @@
     "id": "1999:355",
     "name": "kasinolagen",
     "type": "law",
-    "alternativeNames": []
+    "alternativeNames": [],
+    "category": "Speciell förvaltningsrätt"
   },
   {
     "id": "1999:381",
@@ -1395,7 +1417,8 @@
     "id": "2000:1281",
     "name": "tullagen",
     "type": "law",
-    "alternativeNames": []
+    "alternativeNames": [],
+    "category": "Skatterätt"
   },
   {
     "id": "2000:980",
@@ -1434,7 +1457,8 @@
     "id": "2001:883",
     "name": "revisorslagen",
     "type": "law",
-    "alternativeNames": []
+    "alternativeNames": [],
+    "category": "Associationsrätt"
   },
   {
     "id": "2002:574",
@@ -1455,7 +1479,8 @@
     "id": "2003:364",
     "name": "fartygssäkerhetslagen",
     "type": "law",
-    "alternativeNames": []
+    "alternativeNames": [],
+    "category": "Speciell förvaltningsrätt"
   },
   {
     "id": "2003:376",
@@ -1554,7 +1579,8 @@
     "id": "2005:837",
     "name": "vallagen",
     "type": "law",
-    "alternativeNames": []
+    "alternativeNames": [],
+    "category": "Statsrätt"
   },
   {
     "id": "2006:227",
@@ -1584,7 +1610,8 @@
     "id": "2006:804",
     "name": "livsmedelslagen",
     "type": "law",
-    "alternativeNames": []
+    "alternativeNames": [],
+    "category": "Speciell förvaltningsrätt"
   },
   {
     "id": "2007:612",
@@ -1597,7 +1624,8 @@
     "id": "2008:263",
     "name": "fjärrvärmelagen",
     "type": "law",
-    "alternativeNames": []
+    "alternativeNames": [],
+    "category": "Speciell förvaltningsrätt"
   },
   {
     "id": "2008:355",
@@ -1621,7 +1649,8 @@
     "type": "law",
     "alternativeNames": [
       "DL"
-    ]
+    ],
+    "category": "Arbetsrätt"
   },
   {
     "id": "2008:579",
@@ -1634,7 +1663,8 @@
     "id": "2008:717",
     "name": "FRA-lagen",
     "type": "law",
-    "alternativeNames": []
+    "alternativeNames": [],
+    "category": "Statsrätt"
   },
   {
     "id": "2009:287",
@@ -1660,19 +1690,11 @@
     "category": "Allmän förvaltningsrätt"
   },
   {
-    "id": "2009:400",
-    "name": "sekretesslagen",
-    "type": "law",
-    "alternativeNames": [
-      "OSL"
-    ],
-    "category": "Statsrätt"
-  },
-  {
     "id": "2009:600",
     "name": "språklagen",
     "type": "law",
-    "alternativeNames": []
+    "alternativeNames": [],
+    "category": "Statsrätt"
   },
   {
     "id": "2009:865",
@@ -1711,7 +1733,8 @@
     "id": "2010:1622",
     "name": "alkohollagen",
     "type": "law",
-    "alternativeNames": []
+    "alternativeNames": [],
+    "category": "Speciell förvaltningsrätt"
   },
   {
     "id": "2010:1846",

--- a/data/law-names.json
+++ b/data/law-names.json
@@ -1809,5 +1809,659 @@
     "type": "law",
     "alternativeNames": [],
     "category": "IT-rätt"
+  },
+  {
+    "id": "1891:35 s.1",
+    "name": "sjölagen",
+    "type": "law",
+    "alternativeNames": [
+      "SjöL"
+    ]
+  },
+  {
+    "id": "1904:48 s.1",
+    "name": "samäganderättslagen",
+    "type": "law",
+    "alternativeNames": [
+      "SamägL"
+    ]
+  },
+  {
+    "id": "1921:225",
+    "name": "konkurslagen",
+    "type": "law",
+    "alternativeNames": [
+      "KonkL"
+    ]
+  },
+  {
+    "id": "1956:623",
+    "name": "taxeringslagen",
+    "type": "law",
+    "alternativeNames": [
+      "TaxL"
+    ]
+  },
+  {
+    "id": "1958:110",
+    "name": "strålskyddslagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "id": "1967:198",
+    "name": "folkbokföringslagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "id": "1968:231",
+    "name": "smittskyddslagen",
+    "type": "law",
+    "alternativeNames": [
+      "SmittskL"
+    ]
+  },
+  {
+    "id": "1971:392",
+    "name": "växtförädlarrättslagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "id": "1971:479",
+    "name": "bostadsrättslagen",
+    "type": "law",
+    "alternativeNames": [
+      "BRL"
+    ]
+  },
+  {
+    "id": "1971:511",
+    "name": "livsmedelslagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "id": "1972:429",
+    "name": "rättshjälpslagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "id": "1972:620",
+    "name": "vallagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "id": "1973:349",
+    "name": "studiestödslagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "id": "1973:877",
+    "name": "konsumentköplagen",
+    "type": "law",
+    "alternativeNames": [
+      "KKöpL"
+    ]
+  },
+  {
+    "id": "1973:1176",
+    "name": "vapenlagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "id": "1974:358",
+    "name": "förtroendemannalagen",
+    "type": "law",
+    "alternativeNames": [
+      "FML"
+    ]
+  },
+  {
+    "id": "1975:1385",
+    "name": "aktiebolagslagen",
+    "type": "law",
+    "alternativeNames": [
+      "ABL"
+    ]
+  },
+  {
+    "id": "1975:1418",
+    "name": "marknadsföringslagen",
+    "type": "law",
+    "alternativeNames": [
+      "MFL"
+    ]
+  },
+  {
+    "id": "1976:125",
+    "name": "bokföringslagen",
+    "type": "law",
+    "alternativeNames": [
+      "BFL"
+    ]
+  },
+  {
+    "id": "1976:511",
+    "name": "",
+    "type": "law",
+    "alternativeNames": [
+      "LOB"
+    ]
+  },
+  {
+    "id": "1977:179",
+    "name": "kommunallagen",
+    "type": "law",
+    "alternativeNames": [
+      "KL",
+      "KomL"
+    ]
+  },
+  {
+    "id": "1977:218",
+    "name": "högskolelagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "id": "1977:477",
+    "name": "körkortslagen",
+    "type": "law",
+    "alternativeNames": [
+      "KörkL"
+    ]
+  },
+  {
+    "id": "1977:722",
+    "name": "körkortsförordningen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "id": "1977:981",
+    "name": "konsumentkreditlagen",
+    "type": "law",
+    "alternativeNames": [
+      "KKrL"
+    ]
+  },
+  {
+    "id": "1979:559",
+    "name": "yrkestrafiklagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "id": "1980:369",
+    "name": "epizootilagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "id": "1980:376",
+    "name": "utlänningslagen",
+    "type": "law",
+    "alternativeNames": [
+      "UtlL"
+    ]
+  },
+  {
+    "id": "1980:620",
+    "name": "socialtjänstlagen",
+    "type": "law",
+    "alternativeNames": [
+      "SoL"
+    ]
+  },
+  {
+    "id": "1982:729",
+    "name": "konkurrenslagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "id": "1982:763",
+    "name": "hälso- och sjukvårdslagen",
+    "type": "law",
+    "alternativeNames": [
+      "HSL"
+    ]
+  },
+  {
+    "id": "1982:1011",
+    "name": "lotterilagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "id": "1986:223",
+    "name": "förvaltningslagen",
+    "type": "law",
+    "alternativeNames": [
+      "FL"
+    ]
+  },
+  {
+    "id": "1987:10",
+    "name": "plan- och bygglagen",
+    "type": "law",
+    "alternativeNames": [
+      "PBL"
+    ]
+  },
+  {
+    "id": "1987:1065",
+    "name": "tullagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "id": "1988:49",
+    "name": "fartygssäkerhetslagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "id": "1988:263",
+    "name": "yrkestrafiklagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "id": "1988:360",
+    "name": "",
+    "type": "law",
+    "alternativeNames": [
+      "LBH"
+    ]
+  },
+  {
+    "id": "1988:1472",
+    "name": "smittskyddslagen",
+    "type": "law",
+    "alternativeNames": [
+      "SmittskL"
+    ]
+  },
+  {
+    "id": "1988:1604",
+    "name": "produktsäkerhetslagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "id": "1989:529",
+    "name": "utlänningslagen",
+    "type": "law",
+    "alternativeNames": [
+      "UtlL"
+    ]
+  },
+  {
+    "id": "1991:601",
+    "name": "prisinformationslagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "id": "1992:830",
+    "name": "konsumentkreditlagen",
+    "type": "law",
+    "alternativeNames": [
+      "KKrL"
+    ]
+  },
+  {
+    "id": "1992:859",
+    "name": "läkemedelslagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "id": "1993:20",
+    "name": "konkurrenslagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "id": "1994:334",
+    "name": "skuldsaneringslagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "id": "1994:1219",
+    "name": "europakonventionen",
+    "type": "law",
+    "alternativeNames": [
+      "EKMR"
+    ]
+  },
+  {
+    "id": "1994:1550",
+    "name": "tullagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "id": "1994:1738",
+    "name": "alkohollagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "id": "1995:450",
+    "name": "marknadsföringslagen",
+    "type": "law",
+    "alternativeNames": [
+      "MFL"
+    ]
+  },
+  {
+    "id": "1997:157",
+    "name": "vallagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "id": "2000:599",
+    "name": "naturgaslagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "id": "2002:562",
+    "name": "e-handelslagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "id": "2010:361",
+    "name": "polisdatalagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "id": "2010:500",
+    "name": "luftfartslagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "id": "2010:800",
+    "name": "skollagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "id": "2010:1045",
+    "name": "postlagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "id": "2010:1877",
+    "name": "varumärkeslagen",
+    "type": "law",
+    "alternativeNames": [
+      "VML"
+    ]
+  },
+  {
+    "id": "2010:1932",
+    "name": "delgivningslagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "id": "2010:2043",
+    "name": "försäkringsrörelselagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "id": "2011:666",
+    "name": "fastighetsmäklarlagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "id": "2011:1029",
+    "name": "",
+    "type": "law",
+    "alternativeNames": [
+      "LUFS"
+    ]
+  },
+  {
+    "id": "2012:210",
+    "name": "yrkestrafiklagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "id": "2013:801",
+    "name": "bibliotekslagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "id": "2014:322",
+    "name": "brottsskadelagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "id": "2014:801",
+    "name": "riksdagsordningen",
+    "type": "law",
+    "alternativeNames": [
+      "RO"
+    ]
+  },
+  {
+    "id": "2016:253",
+    "name": "tullagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "id": "2016:675",
+    "name": "skuldsaneringslagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "id": "2016:1013",
+    "name": "namnlagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "id": "2016:1146",
+    "name": "",
+    "type": "law",
+    "alternativeNames": [
+      "LUF"
+    ]
+  },
+  {
+    "id": "2016:1147",
+    "name": "",
+    "type": "law",
+    "alternativeNames": [
+      "LUK"
+    ]
+  },
+  {
+    "id": "2017:630",
+    "name": "penningtvättslagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "id": "2017:725",
+    "name": "kommunallagen",
+    "type": "law",
+    "alternativeNames": [
+      "KL",
+      "KomL"
+    ]
+  },
+  {
+    "id": "2018:181",
+    "name": "järnvägstrafiklagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "id": "2018:396",
+    "name": "strålskyddslagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "id": "2018:558",
+    "name": "företagshemlighetslagen",
+    "type": "law",
+    "alternativeNames": [
+      "FHL"
+    ]
+  },
+  {
+    "id": "2018:585",
+    "name": "säkerhetsskyddslagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "id": "2018:1138",
+    "name": "spellagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "id": "2018:1192",
+    "name": "djurskyddslagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "id": "2018:1197",
+    "name": "barnkonventionen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "id": "2018:1200",
+    "name": "kamerabevakningslagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "id": "2018:1217",
+    "name": "paketreselagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "id": "2018:1218",
+    "name": "resegarantilagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "id": "2018:1653",
+    "name": "företagsnamnslagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "id": "2018:2088",
+    "name": "tobakslagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "id": "2021:516",
+    "name": "fastighetsmäklarlagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "id": "2021:890",
+    "name": "visselblåsarlagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "id": "2022:260",
+    "name": "konsumentköplagen",
+    "type": "law",
+    "alternativeNames": [
+      "KKöpL"
+    ]
+  },
+  {
+    "id": "2022:482",
+    "name": "",
+    "type": "law",
+    "alternativeNames": [
+      "LEK"
+    ]
+  },
+  {
+    "id": "2022:666",
+    "name": "terroristbrottslagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "id": "2022:725",
+    "name": "växtskyddslagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "id": "2023:200",
+    "name": "mervärdesskattelagen",
+    "type": "law",
+    "alternativeNames": [
+      "ML"
+    ]
+  },
+  {
+    "id": "2024:945",
+    "name": "patentlagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "id": "2025:400",
+    "name": "socialtjänstlagen",
+    "type": "law",
+    "alternativeNames": [
+      "SoL"
+    ]
+  },
+  {
+    "id": "2026:408",
+    "name": "vapenlagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "id": "2026:1011",
+    "name": "konsumentkreditlagen",
+    "type": "law",
+    "alternativeNames": [
+      "KKrL"
+    ]
   }
 ]

--- a/data/law-names.json
+++ b/data/law-names.json
@@ -1,6 +1,8 @@
 [
   {
-    "id": "1736:0123_1",
+    "ids": [
+      "1736:0123_1"
+    ],
     "name": "byggningabalken",
     "type": "law",
     "alternativeNames": [
@@ -9,7 +11,9 @@
     "category": "Sakrätt"
   },
   {
-    "id": "1736:0123_2",
+    "ids": [
+      "1736:0123_2"
+    ],
     "name": "handelsbalken",
     "type": "law",
     "alternativeNames": [
@@ -18,7 +22,9 @@
     "category": "Sakrätt"
   },
   {
-    "id": "1810:0926",
+    "ids": [
+      "1810:0926"
+    ],
     "name": "successionsordningen",
     "type": "law",
     "alternativeNames": [
@@ -27,7 +33,9 @@
     "category": "Statsrätt"
   },
   {
-    "id": "1845:50_s._1",
+    "ids": [
+      "1845:50_s._1"
+    ],
     "name": "lösöresköpslagen",
     "type": "law",
     "alternativeNames": [
@@ -36,7 +44,21 @@
     "category": "Sakrätt"
   },
   {
-    "id": "1904:26_1",
+    "ids": [
+      "1891:35 s.1",
+      "1994:1009"
+    ],
+    "name": "sjölagen",
+    "type": "law",
+    "alternativeNames": [
+      "SjöL"
+    ],
+    "category": "Speciell avtalsrätt"
+  },
+  {
+    "ids": [
+      "1904:26_1"
+    ],
     "name": "",
     "type": "law",
     "alternativeNames": [
@@ -44,7 +66,19 @@
     ]
   },
   {
-    "id": "1915:218",
+    "ids": [
+      "1904:48 s.1"
+    ],
+    "name": "samäganderättslagen",
+    "type": "law",
+    "alternativeNames": [
+      "SamägL"
+    ]
+  },
+  {
+    "ids": [
+      "1915:218"
+    ],
     "name": "avtalslagen",
     "type": "law",
     "alternativeNames": [
@@ -53,7 +87,9 @@
     "category": "Allmän avtalsrätt"
   },
   {
-    "id": "1920:405",
+    "ids": [
+      "1920:405"
+    ],
     "name": "giftermålsbalken",
     "type": "law",
     "alternativeNames": [
@@ -62,21 +98,40 @@
     "category": "Familjerätt"
   },
   {
-    "id": "1932:130",
+    "ids": [
+      "1921:225",
+      "1987:672"
+    ],
+    "name": "konkurslagen",
+    "type": "law",
+    "alternativeNames": [
+      "KL",
+      "KonkL"
+    ],
+    "category": "Processrätt"
+  },
+  {
+    "ids": [
+      "1932:130"
+    ],
     "name": "växellagen",
     "type": "law",
     "alternativeNames": [],
     "category": "Fordringsrätt"
   },
   {
-    "id": "1932:131",
+    "ids": [
+      "1932:131"
+    ],
     "name": "checklagen",
     "type": "law",
     "alternativeNames": [],
     "category": "Fordringsrätt"
   },
   {
-    "id": "1936:81",
+    "ids": [
+      "1936:81"
+    ],
     "name": "skuldebrevslagen",
     "type": "law",
     "alternativeNames": [
@@ -85,7 +140,9 @@
     "category": "Fordringsrätt"
   },
   {
-    "id": "1936:83",
+    "ids": [
+      "1936:83"
+    ],
     "name": "gåvolagen",
     "type": "law",
     "alternativeNames": [
@@ -94,7 +151,9 @@
     "category": "Speciell avtalsrätt"
   },
   {
-    "id": "1942:740",
+    "ids": [
+      "1942:740"
+    ],
     "name": "rättegångsbalken",
     "type": "law",
     "alternativeNames": [
@@ -103,7 +162,9 @@
     "category": "Processrätt"
   },
   {
-    "id": "1946:808",
+    "ids": [
+      "1946:808"
+    ],
     "name": "",
     "type": "law",
     "alternativeNames": [
@@ -111,7 +172,9 @@
     ]
   },
   {
-    "id": "1949:105",
+    "ids": [
+      "1949:105"
+    ],
     "name": "tryckfrihetsförordningen",
     "type": "law",
     "alternativeNames": [
@@ -120,7 +183,9 @@
     "category": "Statsrätt"
   },
   {
-    "id": "1949:381",
+    "ids": [
+      "1949:381"
+    ],
     "name": "föräldrabalken",
     "type": "law",
     "alternativeNames": [
@@ -129,7 +194,21 @@
     "category": "Familjerätt"
   },
   {
-    "id": "1957:259",
+    "ids": [
+      "1956:623",
+      "1990:324"
+    ],
+    "name": "taxeringslagen",
+    "type": "law",
+    "alternativeNames": [
+      "TaxL"
+    ],
+    "category": "Skatterätt"
+  },
+  {
+    "ids": [
+      "1957:259"
+    ],
     "name": "",
     "type": "law",
     "alternativeNames": [
@@ -137,14 +216,30 @@
     ]
   },
   {
-    "id": "1957:297",
+    "ids": [
+      "1957:297",
+      "2010:500"
+    ],
     "name": "luftfartslagen",
     "type": "law",
     "alternativeNames": [],
     "category": "Speciell förvaltningsrätt"
   },
   {
-    "id": "1958:637",
+    "ids": [
+      "1958:110",
+      "1988:220",
+      "2018:396"
+    ],
+    "name": "strålskyddslagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "Speciell förvaltningsrätt"
+  },
+  {
+    "ids": [
+      "1958:637"
+    ],
     "name": "ärvdabalken",
     "type": "law",
     "alternativeNames": [
@@ -153,7 +248,10 @@
     "category": "Familjerätt"
   },
   {
-    "id": "1960:644",
+    "ids": [
+      "1960:644",
+      "2010:1877"
+    ],
     "name": "varumärkeslagen",
     "type": "law",
     "alternativeNames": [
@@ -162,14 +260,18 @@
     "category": "Immaterialrätt"
   },
   {
-    "id": "1960:645",
+    "ids": [
+      "1960:645"
+    ],
     "name": "kollektivmärkeslagen",
     "type": "law",
     "alternativeNames": [],
     "category": "Immaterialrätt"
   },
   {
-    "id": "1960:729",
+    "ids": [
+      "1960:729"
+    ],
     "name": "upphovsrättslagen",
     "type": "law",
     "alternativeNames": [
@@ -178,7 +280,9 @@
     "category": "Immaterialrätt"
   },
   {
-    "id": "1962:700",
+    "ids": [
+      "1962:700"
+    ],
     "name": "brottsbalken",
     "type": "law",
     "alternativeNames": [
@@ -187,7 +291,18 @@
     "category": "Straffrätt"
   },
   {
-    "id": "1964:163",
+    "ids": [
+      "1964:19"
+    ],
+    "name": "krigshandelslagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "Sakrätt"
+  },
+  {
+    "ids": [
+      "1964:163"
+    ],
     "name": "",
     "type": "law",
     "alternativeNames": [
@@ -195,20 +310,28 @@
     ]
   },
   {
-    "id": "1964:19",
-    "name": "krigshandelslagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "Sakrätt"
-  },
-  {
-    "id": "1966:209",
+    "ids": [
+      "1966:209"
+    ],
     "name": "virkesmätningslagen",
     "type": "law",
     "alternativeNames": []
   },
   {
-    "id": "1967:837",
+    "ids": [
+      "1967:198",
+      "1991:481"
+    ],
+    "name": "folkbokföringslagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "Associationsrätt"
+  },
+  {
+    "ids": [
+      "1967:837",
+      "2024:945"
+    ],
     "name": "patentlagen",
     "type": "law",
     "alternativeNames": [
@@ -217,13 +340,17 @@
     "category": "Immaterialrätt"
   },
   {
-    "id": "1968:45",
+    "ids": [
+      "1968:45"
+    ],
     "name": "atomansvarighetslagen",
     "type": "law",
     "alternativeNames": []
   },
   {
-    "id": "1968:64",
+    "ids": [
+      "1968:64"
+    ],
     "name": "narkotikastrafflagen",
     "type": "law",
     "alternativeNames": [
@@ -232,27 +359,49 @@
     "category": "Straffrätt"
   },
   {
-    "id": "1970:428",
+    "ids": [
+      "1968:231",
+      "1988:1472",
+      "2004:168"
+    ],
+    "name": "smittskyddslagen",
+    "type": "law",
+    "alternativeNames": [
+      "SmittskL"
+    ],
+    "category": "Speciell förvaltningsrätt"
+  },
+  {
+    "ids": [
+      "1970:428",
+      "2010:1932"
+    ],
     "name": "delgivningslagen",
     "type": "law",
     "alternativeNames": []
   },
   {
-    "id": "1970:485",
+    "ids": [
+      "1970:485"
+    ],
     "name": "mönsterskyddslagen",
     "type": "law",
     "alternativeNames": [],
     "category": "Immaterialrätt"
   },
   {
-    "id": "1970:624",
+    "ids": [
+      "1970:624"
+    ],
     "name": "kupongskattelagen",
     "type": "law",
     "alternativeNames": [],
     "category": "Skatterätt"
   },
   {
-    "id": "1970:979",
+    "ids": [
+      "1970:979"
+    ],
     "name": "förmånsrättslagen",
     "type": "law",
     "alternativeNames": [
@@ -261,7 +410,9 @@
     "category": "Sakrätt"
   },
   {
-    "id": "1970:988",
+    "ids": [
+      "1970:988"
+    ],
     "name": "fastighetsbildningslagen",
     "type": "law",
     "alternativeNames": [
@@ -270,7 +421,9 @@
     "category": "Fastighetsrätt"
   },
   {
-    "id": "1970:994",
+    "ids": [
+      "1970:994"
+    ],
     "name": "jordabalken",
     "type": "law",
     "alternativeNames": [
@@ -279,7 +432,9 @@
     "category": "Fastighetsrätt"
   },
   {
-    "id": "1970:995",
+    "ids": [
+      "1970:995"
+    ],
     "name": "",
     "type": "law",
     "alternativeNames": [
@@ -287,46 +442,9 @@
     ]
   },
   {
-    "id": "1971:289",
-    "name": "",
-    "type": "law",
-    "alternativeNames": [
-      "AFDL"
-    ]
-  },
-  {
-    "id": "1971:291",
-    "name": "förvaltningsprocesslagen",
-    "type": "law",
-    "alternativeNames": [
-      "FPL"
+    "ids": [
+      "1971:69"
     ],
-    "category": "Allmän förvaltningsrätt"
-  },
-  {
-    "id": "1971:309",
-    "name": "",
-    "type": "law",
-    "alternativeNames": [
-      "BehL"
-    ]
-  },
-  {
-    "id": "1971:437",
-    "name": "rennäringslagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "1971:494",
-    "name": "",
-    "type": "law",
-    "alternativeNames": [
-      "FfL"
-    ]
-  },
-  {
-    "id": "1971:69",
     "name": "skattebrottslagen",
     "type": "law",
     "alternativeNames": [
@@ -335,7 +453,90 @@
     "category": "Straffrätt"
   },
   {
-    "id": "1971:796",
+    "ids": [
+      "1971:289"
+    ],
+    "name": "",
+    "type": "law",
+    "alternativeNames": [
+      "AFDL"
+    ]
+  },
+  {
+    "ids": [
+      "1971:291"
+    ],
+    "name": "förvaltningsprocesslagen",
+    "type": "law",
+    "alternativeNames": [
+      "FPL"
+    ],
+    "category": "Allmän förvaltningsrätt"
+  },
+  {
+    "ids": [
+      "1971:309"
+    ],
+    "name": "",
+    "type": "law",
+    "alternativeNames": [
+      "BehL"
+    ]
+  },
+  {
+    "ids": [
+      "1971:392",
+      "1997:306"
+    ],
+    "name": "växtförädlarrättslagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "Immaterialrätt"
+  },
+  {
+    "ids": [
+      "1971:437"
+    ],
+    "name": "rennäringslagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "ids": [
+      "1971:479",
+      "1991:614"
+    ],
+    "name": "bostadsrättslagen",
+    "type": "law",
+    "alternativeNames": [
+      "BRL"
+    ],
+    "category": "Fastighetsrätt"
+  },
+  {
+    "ids": [
+      "1971:494"
+    ],
+    "name": "",
+    "type": "law",
+    "alternativeNames": [
+      "FfL"
+    ]
+  },
+  {
+    "ids": [
+      "1971:511",
+      "2006:804"
+    ],
+    "name": "livsmedelslagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "Speciell förvaltningsrätt"
+  },
+  {
+    "ids": [
+      "1971:796"
+    ],
     "name": "",
     "type": "law",
     "alternativeNames": [
@@ -343,7 +544,9 @@
     ]
   },
   {
-    "id": "1971:948",
+    "ids": [
+      "1971:948"
+    ],
     "name": "väglagen",
     "type": "law",
     "alternativeNames": [
@@ -352,19 +555,26 @@
     "category": "Speciell förvaltningsrätt"
   },
   {
-    "id": "1972:204",
+    "ids": [
+      "1972:204",
+      "2018:1218"
+    ],
     "name": "resegarantilagen",
     "type": "law",
     "alternativeNames": []
   },
   {
-    "id": "1972:205",
+    "ids": [
+      "1972:205"
+    ],
     "name": "permutationslagen",
     "type": "law",
     "alternativeNames": []
   },
   {
-    "id": "1972:207",
+    "ids": [
+      "1972:207"
+    ],
     "name": "skadeståndslagen",
     "type": "law",
     "alternativeNames": [
@@ -373,14 +583,40 @@
     "category": "Skadeståndsrätt"
   },
   {
-    "id": "1972:318",
+    "ids": [
+      "1972:318",
+      "2022:725"
+    ],
     "name": "växtskyddslagen",
     "type": "law",
     "alternativeNames": [],
     "category": "Speciell förvaltningsrätt"
   },
   {
-    "id": "1972:719",
+    "ids": [
+      "1972:429",
+      "1996:1619"
+    ],
+    "name": "rättshjälpslagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "Processrätt"
+  },
+  {
+    "ids": [
+      "1972:620",
+      "1997:157",
+      "2005:837"
+    ],
+    "name": "vallagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "Statsrätt"
+  },
+  {
+    "ids": [
+      "1972:719"
+    ],
     "name": "expropriationslagen",
     "type": "law",
     "alternativeNames": [
@@ -390,539 +626,29 @@
     "category": "Fastighetsrätt"
   },
   {
-    "id": "1973:1144",
-    "name": "ledningsrättslagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "Fastighetsrätt"
-  },
-  {
-    "id": "1973:1149",
-    "name": "anläggningslagen",
-    "type": "law",
-    "alternativeNames": [
-      "AL"
+    "ids": [
+      "1973:282"
     ],
-    "category": "Fastighetsrätt"
-  },
-  {
-    "id": "1973:1173",
-    "name": "kreditupplysningslagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "Fordringsrätt"
-  },
-  {
-    "id": "1973:282",
     "name": "sjömanslagen",
     "type": "law",
     "alternativeNames": []
   },
   {
-    "id": "1974:152",
-    "name": "regeringsformen",
-    "type": "law",
-    "alternativeNames": [
-      "RF"
+    "ids": [
+      "1973:349",
+      "1999:1395"
     ],
-    "category": "Statsrätt"
-  },
-  {
-    "id": "1974:153",
-    "name": "riksdagsordningen",
-    "type": "law",
-    "alternativeNames": [
-      "RO"
-    ],
-    "category": "Statsrätt"
-  },
-  {
-    "id": "1974:156",
-    "name": "firmalagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "Associationsrätt"
-  },
-  {
-    "id": "1974:157",
-    "name": "handelsregisterlagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "Sakrätt"
-  },
-  {
-    "id": "1974:158",
-    "name": "prokuralagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "Allmän avtalsrätt"
-  },
-  {
-    "id": "1974:182",
-    "name": "inkassolagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "Fordringsrätt"
-  },
-  {
-    "id": "1974:211",
-    "name": "bisjukdomslagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "1974:371",
-    "name": "lagen om rättegången i arbetstvister",
-    "type": "law",
-    "alternativeNames": [
-      "LRA"
-    ],
-    "category": "Arbetsrätt"
-  },
-  {
-    "id": "1974:595",
-    "name": "abortlagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "1975:1313",
-    "name": "terrängkörningslagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "1975:1410",
-    "name": "trafikskadelagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "Skadeståndsrätt"
-  },
-  {
-    "id": "1975:197",
-    "name": "oljekrislagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "1975:580",
-    "name": "steriliseringslagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "1975:635",
-    "name": "räntelagen",
-    "type": "law",
-    "alternativeNames": [
-      "RänteL"
-    ],
-    "category": "Fordringsrätt"
-  },
-  {
-    "id": "1976:19",
-    "name": "lagföringslagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "1976:298",
-    "name": "utsädeslagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "1976:580",
-    "name": "medbestämmandelagen",
-    "type": "law",
-    "alternativeNames": [
-      "MBL"
-    ],
-    "category": "Arbetsrätt"
-  },
-  {
-    "id": "1976:633",
-    "name": "kungörandelagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "1977:1160",
-    "name": "arbetsmiljölagen",
-    "type": "law",
-    "alternativeNames": [
-      "AML"
-    ],
-    "category": "Arbetsrätt"
-  },
-  {
-    "id": "1977:480",
-    "name": "semesterlagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "Arbetsrätt"
-  },
-  {
-    "id": "1977:792",
-    "name": "bostadsförvaltningslagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "Allmän förvaltningsrätt"
-  },
-  {
-    "id": "1978:262",
-    "name": "förfogandelagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "1978:268",
-    "name": "ransoneringslagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "1978:302",
-    "name": "passlagen",
+    "name": "studiestödslagen",
     "type": "law",
     "alternativeNames": [],
     "category": "Speciell förvaltningsrätt"
   },
   {
-    "id": "1978:304",
-    "name": "hyresförhandlingslagen",
-    "type": "law",
-    "alternativeNames": [
-      "HFL"
+    "ids": [
+      "1973:877",
+      "1990:932",
+      "2022:260"
     ],
-    "category": "Speciell avtalsrätt"
-  },
-  {
-    "id": "1978:413",
-    "name": "brottsskadelagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "Skadeståndsrätt"
-  },
-  {
-    "id": "1978:520",
-    "name": "familjebidragslagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "1979:1152",
-    "name": "fastighetstaxeringslagen",
-    "type": "law",
-    "alternativeNames": [
-      "FTL"
-    ],
-    "category": "Skatterätt"
-  },
-  {
-    "id": "1979:189",
-    "name": "bötesverkställighetslagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "1979:230",
-    "name": "jordförvärvslagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "1979:369",
-    "name": "folkomröstningslagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "1979:429",
-    "name": "skogsvårdslagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "Speciell förvaltningsrätt"
-  },
-  {
-    "id": "1980:100",
-    "name": "sekretesslagen",
-    "type": "law",
-    "alternativeNames": [
-      "SekrL"
-    ]
-  },
-  {
-    "id": "1980:152",
-    "name": "containerlagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "1980:657",
-    "name": "sekretessförordningen",
-    "type": "law",
-    "alternativeNames": [
-      "SekrF"
-    ]
-  },
-  {
-    "id": "1981:130",
-    "name": "preskriptionslagen",
-    "type": "law",
-    "alternativeNames": [
-      "PreskL"
-    ],
-    "category": "Fordringsrätt"
-  },
-  {
-    "id": "1981:774",
-    "name": "utsökningsbalken",
-    "type": "law",
-    "alternativeNames": [
-      "UB"
-    ],
-    "category": "Processrätt"
-  },
-  {
-    "id": "1981:981",
-    "name": "utsökningsförordningen",
-    "type": "law",
-    "alternativeNames": [
-      "UF"
-    ]
-  },
-  {
-    "id": "1982:670",
-    "name": "namnlagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "Familjerätt"
-  },
-  {
-    "id": "1982:673",
-    "name": "arbetstidslagen",
-    "type": "law",
-    "alternativeNames": [
-      "ATL"
-    ],
-    "category": "Arbetsrätt"
-  },
-  {
-    "id": "1982:713",
-    "name": "försäkringsrörelselagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "Socialrätt"
-  },
-  {
-    "id": "1982:80",
-    "name": "anställningsskyddslagen",
-    "type": "law",
-    "alternativeNames": [
-      "LAS"
-    ],
-    "category": "Arbetsrätt"
-  },
-  {
-    "id": "1983:929",
-    "name": "mönstringslagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "1984:292",
-    "name": "",
-    "type": "law",
-    "alternativeNames": [
-      "AVLN"
-    ]
-  },
-  {
-    "id": "1984:387",
-    "name": "polislagen",
-    "type": "law",
-    "alternativeNames": [
-      "PolisL",
-      "PL"
-    ],
-    "category": "Speciell förvaltningsrätt"
-  },
-  {
-    "id": "1985:1100",
-    "name": "skollagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "Speciell förvaltningsrätt"
-  },
-  {
-    "id": "1985:125",
-    "name": "tandvårdslagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "Speciell förvaltningsrätt"
-  },
-  {
-    "id": "1985:192",
-    "name": "järnvägstrafiklagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "Speciell förvaltningsrätt"
-  },
-  {
-    "id": "1985:206",
-    "name": "viteslagen",
-    "type": "law",
-    "alternativeNames": [
-      "VitesL"
-    ]
-  },
-  {
-    "id": "1985:716",
-    "name": "konsumenttjänstlagen",
-    "type": "law",
-    "alternativeNames": [
-      "KTjL"
-    ],
-    "category": "Speciell avtalsrätt"
-  },
-  {
-    "id": "1987:11",
-    "name": "",
-    "type": "law",
-    "alternativeNames": [
-      "ESL"
-    ]
-  },
-  {
-    "id": "1987:230",
-    "name": "äktenskapsbalken",
-    "type": "law",
-    "alternativeNames": [
-      "ÄktB"
-    ],
-    "category": "Familjerätt"
-  },
-  {
-    "id": "1987:259",
-    "name": "jaktlagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "Speciell förvaltningsrätt"
-  },
-  {
-    "id": "1987:619",
-    "name": "sparbankslagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "Ekonomisk rätt"
-  },
-  {
-    "id": "1987:672",
-    "name": "konkurslagen",
-    "type": "law",
-    "alternativeNames": [
-      "KL"
-    ],
-    "category": "Processrätt"
-  },
-  {
-    "id": "1987:822",
-    "name": "lagen om internationella köp",
-    "type": "law",
-    "alternativeNames": [
-      "CISG"
-    ]
-  },
-  {
-    "id": "1988:220",
-    "name": "strålskyddslagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "Speciell förvaltningsrätt"
-  },
-  {
-    "id": "1988:254",
-    "name": "knivlagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "Straffrätt"
-  },
-  {
-    "id": "1988:534",
-    "name": "djurskyddslagen",
-    "type": "law",
-    "alternativeNames": [
-      "DjurskL"
-    ],
-    "category": "Speciell förvaltningsrätt"
-  },
-  {
-    "id": "1988:870",
-    "name": "lagen om vård av missbrukare i vissa fall",
-    "type": "law",
-    "alternativeNames": [
-      "LVM"
-    ]
-  },
-  {
-    "id": "1989:978",
-    "name": "prisregleringslagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "1990:1144",
-    "name": "begravningslagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "Speciell förvaltningsrätt"
-  },
-  {
-    "id": "1990:324",
-    "name": "taxeringslagen",
-    "type": "law",
-    "alternativeNames": [
-      "TaxL"
-    ],
-    "category": "Skatterätt"
-  },
-  {
-    "id": "1990:52",
-    "name": "lagen med särskilda bestämmelser om vård av unga",
-    "type": "law",
-    "alternativeNames": [
-      "LVU"
-    ]
-  },
-  {
-    "id": "1990:746",
-    "name": "lagen om betalningsföreläggande och handräckning",
-    "type": "law",
-    "alternativeNames": [
-      "LBH"
-    ]
-  },
-  {
-    "id": "1990:782",
-    "name": "arkivlagen",
-    "type": "law",
-    "alternativeNames": [
-      "ArkivL"
-    ],
-    "category": "Allmän förvaltningsrätt"
-  },
-  {
-    "id": "1990:931",
-    "name": "köplagen",
-    "type": "law",
-    "alternativeNames": [
-      "KöpL"
-    ],
-    "category": "Speciell avtalsrätt"
-  },
-  {
-    "id": "1990:932",
     "name": "konsumentköplagen",
     "type": "law",
     "alternativeNames": [
@@ -931,69 +657,275 @@
     "category": "Speciell avtalsrätt"
   },
   {
-    "id": "1991:1128",
-    "name": "lagen om psykiatrisk tvångsvård",
-    "type": "law",
-    "alternativeNames": [
-      "LPT"
-    ]
-  },
-  {
-    "id": "1991:1129",
-    "name": "lagen om rättspsykiatrisk vård",
-    "type": "law",
-    "alternativeNames": [
-      "LRV"
-    ]
-  },
-  {
-    "id": "1991:1469",
-    "name": "yttrandefrihetsgrundlagen",
-    "type": "law",
-    "alternativeNames": [
-      "YGL"
+    "ids": [
+      "1973:1144"
     ],
-    "category": "Statsrätt"
-  },
-  {
-    "id": "1991:45",
-    "name": "minerallagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "Speciell förvaltningsrätt"
-  },
-  {
-    "id": "1991:481",
-    "name": "folkbokföringslagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "Associationsrätt"
-  },
-  {
-    "id": "1991:586",
-    "name": "lagen om särskild inkomstskatt för utomlands bosatta",
-    "type": "law",
-    "alternativeNames": [
-      "SINK"
-    ]
-  },
-  {
-    "id": "1991:614",
-    "name": "bostadsrättslagen",
+    "name": "ledningsrättslagen",
     "type": "law",
     "alternativeNames": [],
     "category": "Fastighetsrätt"
   },
   {
-    "id": "1991:641",
-    "name": "",
+    "ids": [
+      "1973:1149"
+    ],
+    "name": "anläggningslagen",
     "type": "law",
     "alternativeNames": [
-      "BRL"
+      "AL"
+    ],
+    "category": "Fastighetsrätt"
+  },
+  {
+    "ids": [
+      "1973:1173"
+    ],
+    "name": "kreditupplysningslagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "Fordringsrätt"
+  },
+  {
+    "ids": [
+      "1973:1176",
+      "1996:67",
+      "2026:408"
+    ],
+    "name": "vapenlagen",
+    "type": "law",
+    "alternativeNames": [
+      "VapenL"
+    ],
+    "category": "Speciell förvaltningsrätt"
+  },
+  {
+    "ids": [
+      "1974:152"
+    ],
+    "name": "regeringsformen",
+    "type": "law",
+    "alternativeNames": [
+      "RF"
+    ],
+    "category": "Statsrätt"
+  },
+  {
+    "ids": [
+      "1974:153",
+      "2014:801"
+    ],
+    "name": "riksdagsordningen",
+    "type": "law",
+    "alternativeNames": [
+      "RO"
+    ],
+    "category": "Statsrätt"
+  },
+  {
+    "ids": [
+      "1974:156"
+    ],
+    "name": "firmalagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "Associationsrätt"
+  },
+  {
+    "ids": [
+      "1974:157"
+    ],
+    "name": "handelsregisterlagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "Sakrätt"
+  },
+  {
+    "ids": [
+      "1974:158"
+    ],
+    "name": "prokuralagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "Allmän avtalsrätt"
+  },
+  {
+    "ids": [
+      "1974:182"
+    ],
+    "name": "inkassolagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "Fordringsrätt"
+  },
+  {
+    "ids": [
+      "1974:211"
+    ],
+    "name": "bisjukdomslagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "ids": [
+      "1974:358"
+    ],
+    "name": "förtroendemannalagen",
+    "type": "law",
+    "alternativeNames": [
+      "FML"
     ]
   },
   {
-    "id": "1991:900",
+    "ids": [
+      "1974:371"
+    ],
+    "name": "lagen om rättegången i arbetstvister",
+    "type": "law",
+    "alternativeNames": [
+      "LRA"
+    ],
+    "category": "Arbetsrätt"
+  },
+  {
+    "ids": [
+      "1974:595"
+    ],
+    "name": "abortlagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "ids": [
+      "1975:197"
+    ],
+    "name": "oljekrislagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "ids": [
+      "1975:580"
+    ],
+    "name": "steriliseringslagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "ids": [
+      "1975:635"
+    ],
+    "name": "räntelagen",
+    "type": "law",
+    "alternativeNames": [
+      "RänteL"
+    ],
+    "category": "Fordringsrätt"
+  },
+  {
+    "ids": [
+      "1975:1313"
+    ],
+    "name": "terrängkörningslagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "ids": [
+      "1975:1385",
+      "2005:551"
+    ],
+    "name": "aktiebolagslagen",
+    "type": "law",
+    "alternativeNames": [
+      "ABL"
+    ],
+    "category": "Associationsrätt"
+  },
+  {
+    "ids": [
+      "1975:1410"
+    ],
+    "name": "trafikskadelagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "Skadeståndsrätt"
+  },
+  {
+    "ids": [
+      "1975:1418",
+      "1995:450",
+      "2008:486"
+    ],
+    "name": "marknadsföringslagen",
+    "type": "law",
+    "alternativeNames": [
+      "MFL"
+    ],
+    "category": "Marknadsrätt"
+  },
+  {
+    "ids": [
+      "1976:19"
+    ],
+    "name": "lagföringslagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "ids": [
+      "1976:125",
+      "1999:1078"
+    ],
+    "name": "bokföringslagen",
+    "type": "law",
+    "alternativeNames": [
+      "BFL"
+    ],
+    "category": "Associationsrätt"
+  },
+  {
+    "ids": [
+      "1976:298"
+    ],
+    "name": "utsädeslagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "ids": [
+      "1976:511"
+    ],
+    "name": "",
+    "type": "law",
+    "alternativeNames": [
+      "LOB"
+    ]
+  },
+  {
+    "ids": [
+      "1976:580"
+    ],
+    "name": "medbestämmandelagen",
+    "type": "law",
+    "alternativeNames": [
+      "MBL"
+    ],
+    "category": "Arbetsrätt"
+  },
+  {
+    "ids": [
+      "1976:633"
+    ],
+    "name": "kungörandelagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "ids": [
+      "1977:179",
+      "1991:900",
+      "2017:725"
+    ],
     "name": "kommunallagen",
     "type": "law",
     "alternativeNames": [
@@ -1003,301 +935,20 @@
     "category": "Kommunalrätt"
   },
   {
-    "id": "1992:1433",
-    "name": "sametingslagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "Statsrätt"
-  },
-  {
-    "id": "1992:1434",
+    "ids": [
+      "1977:218",
+      "1992:1434"
+    ],
     "name": "högskolelagen",
     "type": "law",
     "alternativeNames": [],
     "category": "Speciell förvaltningsrätt"
   },
   {
-    "id": "1992:1672",
-    "name": "paketreselagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "Speciell avtalsrätt"
-  },
-  {
-    "id": "1992:1685",
-    "name": "kulturmiljölagen",
-    "type": "law",
-    "alternativeNames": [
-      "KML"
-    ]
-  },
-  {
-    "id": "1992:18",
-    "name": "produktansvarslagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "Skadeståndsrätt"
-  },
-  {
-    "id": "1992:191",
-    "name": "",
-    "type": "law",
-    "alternativeNames": [
-      "Avgift"
-    ]
-  },
-  {
-    "id": "1992:497",
-    "name": "lönegarantilagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "1993:1617",
-    "name": "ordningslagen",
-    "type": "law",
-    "alternativeNames": [
-      "OL"
+    "ids": [
+      "1977:477",
+      "1998:488"
     ],
-    "category": "Speciell förvaltningsrätt"
-  },
-  {
-    "id": "1993:1684",
-    "name": "postlagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "1993:387",
-    "name": "lagen om stöd och service till vissa funktionshindrade",
-    "type": "law",
-    "alternativeNames": [
-      "LSS"
-    ]
-  },
-  {
-    "id": "1993:581",
-    "name": "tobakslagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "Speciell förvaltningsrätt"
-  },
-  {
-    "id": "1993:787",
-    "name": "fiskelagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "Speciell förvaltningsrätt"
-  },
-  {
-    "id": "1994:1000",
-    "name": "lotterilagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "1994:1009",
-    "name": "sjölagen",
-    "type": "law",
-    "alternativeNames": [
-      "SjöL"
-    ],
-    "category": "Speciell avtalsrätt"
-  },
-  {
-    "id": "1994:1220",
-    "name": "stiftelselagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "Associationsrätt"
-  },
-  {
-    "id": "1994:193",
-    "name": "",
-    "type": "law",
-    "alternativeNames": [
-      "IURF"
-    ]
-  },
-  {
-    "id": "1994:200",
-    "name": "mervärdesskattelagen",
-    "type": "law",
-    "alternativeNames": [
-      "ML"
-    ],
-    "category": "Skatterätt"
-  },
-  {
-    "id": "1994:260",
-    "name": "lagen om offentlig anställning",
-    "type": "law",
-    "alternativeNames": [
-      "LOA"
-    ]
-  },
-  {
-    "id": "1994:448",
-    "name": "",
-    "type": "law",
-    "alternativeNames": [
-      "PbrL"
-    ]
-  },
-  {
-    "id": "1994:847",
-    "name": "",
-    "type": "law",
-    "alternativeNames": [
-      "BVL"
-    ]
-  },
-  {
-    "id": "1994:1512",
-    "name": "",
-    "type": "law",
-    "alternativeNames": [
-      "AVLK"
-    ]
-  },
-  {
-    "id": "1995:1000",
-    "name": "pantbankslagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "Ekonomisk rätt"
-  },
-  {
-    "id": "1995:1322",
-    "name": "",
-    "type": "law",
-    "alternativeNames": [
-      "VerksF"
-    ]
-  },
-  {
-    "id": "1995:1554",
-    "name": "årsredovisningslagen",
-    "type": "law",
-    "alternativeNames": [
-      "ÅRL"
-    ],
-    "category": "Associationsrätt"
-  },
-  {
-    "id": "1995:400",
-    "name": "fastighetsmäklarlagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "Sakrätt"
-  },
-  {
-    "id": "1995:584",
-    "name": "föräldraledighetslagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "Familjerätt"
-  },
-  {
-    "id": "1996:242",
-    "name": "ärendelagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "Processrätt"
-  },
-  {
-    "id": "1996:1596",
-    "name": "bibliotekslagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "Speciell förvaltningsrätt"
-  },
-  {
-    "id": "1996:1619",
-    "name": "rättshjälpslagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "Processrätt"
-  },
-  {
-    "id": "1996:627",
-    "name": "säkerhetsskyddslagen",
-    "type": "law",
-    "alternativeNames": [
-      "SäkL"
-    ],
-    "category": "Speciell förvaltningsrätt"
-  },
-  {
-    "id": "1996:67",
-    "name": "vapenlagen",
-    "type": "law",
-    "alternativeNames": [
-      "VapenL"
-    ],
-    "category": "Speciell förvaltningsrätt"
-  },
-  {
-    "id": "1996:799",
-    "name": "patientskadelagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "Skadeståndsrätt"
-  },
-  {
-    "id": "1997:192",
-    "name": "",
-    "type": "law",
-    "alternativeNames": [
-      "LIF"
-    ]
-  },
-  {
-    "id": "1997:288",
-    "name": "elberedskapslagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "1997:306",
-    "name": "växtförädlarrättslagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "Immaterialrätt"
-  },
-  {
-    "id": "1997:483",
-    "name": "skattebetalningslagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "Skatterätt"
-  },
-  {
-    "id": "1997:857",
-    "name": "ellagen",
-    "type": "law",
-    "alternativeNames": [
-      "EL"
-    ]
-  },
-  {
-    "id": "1998:112",
-    "name": "bbs-lagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "IT-rätt"
-  },
-  {
-    "id": "1998:204",
-    "name": "personuppgiftslagen",
-    "type": "law",
-    "alternativeNames": [
-      "PUL"
-    ],
-    "category": "IT-rätt"
-  },
-  {
-    "id": "1998:488",
     "name": "körkortslagen",
     "type": "law",
     "alternativeNames": [
@@ -1305,269 +956,201 @@
     ]
   },
   {
-    "id": "1998:490",
-    "name": "yrkestrafiklagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "Speciell förvaltningsrätt"
-  },
-  {
-    "id": "1998:622",
-    "name": "polisdatalagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "IT-rätt"
-  },
-  {
-    "id": "1998:674",
-    "name": "",
-    "type": "law",
-    "alternativeNames": [
-      "LIP"
-    ]
-  },
-  {
-    "id": "1998:808",
-    "name": "miljöbalken",
-    "type": "law",
-    "alternativeNames": [
-      "MB"
+    "ids": [
+      "1977:480"
     ],
-    "category": "Fastighetsrätt"
+    "name": "semesterlagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "Arbetsrätt"
   },
   {
-    "id": "1998:980",
+    "ids": [
+      "1977:722",
+      "1998:980"
+    ],
     "name": "körkortsförordningen",
     "type": "regulation",
     "alternativeNames": [],
     "category": "Speciell förvaltningsrätt"
   },
   {
-    "id": "1999:1078",
-    "name": "bokföringslagen",
+    "ids": [
+      "1977:792"
+    ],
+    "name": "bostadsförvaltningslagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "Allmän förvaltningsrätt"
+  },
+  {
+    "ids": [
+      "1977:981",
+      "1992:830",
+      "2010:1846",
+      "2026:1011"
+    ],
+    "name": "konsumentkreditlagen",
     "type": "law",
     "alternativeNames": [
-      "BFL"
+      "KKrL"
     ],
-    "category": "Associationsrätt"
+    "category": "Allmän avtalsrätt"
   },
   {
-    "id": "1999:1079",
-    "name": "revisionslagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "Associationsrätt"
-  },
-  {
-    "id": "1999:1229",
-    "name": "inkomstskattelagen",
+    "ids": [
+      "1977:1160"
+    ],
+    "name": "arbetsmiljölagen",
     "type": "law",
     "alternativeNames": [
-      "IL"
+      "AML"
     ],
-    "category": "Skatterätt"
+    "category": "Arbetsrätt"
   },
   {
-    "id": "1999:1395",
-    "name": "studiestödslagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "Speciell förvaltningsrätt"
-  },
-  {
-    "id": "1999:355",
-    "name": "kasinolagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "Speciell förvaltningsrätt"
-  },
-  {
-    "id": "1999:381",
-    "name": "sevesolagen",
+    "ids": [
+      "1978:262"
+    ],
+    "name": "förfogandelagen",
     "type": "law",
     "alternativeNames": []
   },
   {
-    "id": "1999:382",
-    "name": "sevesoförordningen",
-    "type": "regulation",
+    "ids": [
+      "1978:268"
+    ],
+    "name": "ransoneringslagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "ids": [
+      "1978:302"
+    ],
+    "name": "passlagen",
+    "type": "law",
     "alternativeNames": [],
     "category": "Speciell förvaltningsrätt"
   },
   {
-    "id": "1999:657",
+    "ids": [
+      "1978:304"
+    ],
+    "name": "hyresförhandlingslagen",
+    "type": "law",
+    "alternativeNames": [
+      "HFL"
+    ],
+    "category": "Speciell avtalsrätt"
+  },
+  {
+    "ids": [
+      "1978:413",
+      "2014:322"
+    ],
+    "name": "brottsskadelagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "Skadeståndsrätt"
+  },
+  {
+    "ids": [
+      "1978:520"
+    ],
+    "name": "familjebidragslagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "ids": [
+      "1979:189"
+    ],
+    "name": "bötesverkställighetslagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "ids": [
+      "1979:230"
+    ],
+    "name": "jordförvärvslagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "ids": [
+      "1979:369"
+    ],
+    "name": "folkomröstningslagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "ids": [
+      "1979:429"
+    ],
+    "name": "skogsvårdslagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "Speciell förvaltningsrätt"
+  },
+  {
+    "ids": [
+      "1979:559",
+      "1988:263",
+      "1998:490",
+      "2012:210"
+    ],
+    "name": "yrkestrafiklagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "Speciell förvaltningsrätt"
+  },
+  {
+    "ids": [
+      "1979:1152"
+    ],
+    "name": "fastighetstaxeringslagen",
+    "type": "law",
+    "alternativeNames": [
+      "FTL"
+    ],
+    "category": "Skatterätt"
+  },
+  {
+    "ids": [
+      "1980:100"
+    ],
+    "name": "sekretesslagen",
+    "type": "law",
+    "alternativeNames": [
+      "SekrL"
+    ]
+  },
+  {
+    "ids": [
+      "1980:152"
+    ],
+    "name": "containerlagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "ids": [
+      "1980:369",
+      "1999:657"
+    ],
     "name": "epizootilagen",
     "type": "law",
     "alternativeNames": []
   },
   {
-    "id": "1999:658",
-    "name": "zoonoslagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "1999:799",
-    "name": "socialförsäkringslagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "Speciell förvaltningsrätt"
-  },
-  {
-    "id": "2000:1281",
-    "name": "tullagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "Skatterätt"
-  },
-  {
-    "id": "2000:980",
-    "name": "socialavgiftslagen",
-    "type": "law",
-    "alternativeNames": [
-      "SAL"
+    "ids": [
+      "1980:376",
+      "1989:529",
+      "2005:716"
     ],
-    "category": "Skatterätt"
-  },
-  {
-    "id": "2001:1227",
-    "name": "lagen om självdeklarationer och kontrolluppgifter",
-    "type": "law",
-    "alternativeNames": [
-      "LSK"
-    ]
-  },
-  {
-    "id": "2001:453",
-    "name": "socialtjänstlagen",
-    "type": "law",
-    "alternativeNames": [
-      "SoL"
-    ],
-    "category": "Speciell förvaltningsrätt"
-  },
-  {
-    "id": "2001:559",
-    "name": "vägtrafiklagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "Speciell förvaltningsrätt"
-  },
-  {
-    "id": "2001:883",
-    "name": "revisorslagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "Associationsrätt"
-  },
-  {
-    "id": "2002:574",
-    "name": "fordonslagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "Speciell förvaltningsrätt"
-  },
-  {
-    "id": "2003:234",
-    "name": "",
-    "type": "law",
-    "alternativeNames": [
-      "Tillhandahållande"
-    ]
-  },
-  {
-    "id": "2003:364",
-    "name": "fartygssäkerhetslagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "Speciell förvaltningsrätt"
-  },
-  {
-    "id": "2003:376",
-    "name": "sambolagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "Familjerätt"
-  },
-  {
-    "id": "2003:389",
-    "name": "lagen om elektronisk kommunikation",
-    "type": "law",
-    "alternativeNames": [
-      "LEK"
-    ]
-  },
-  {
-    "id": "2003:778",
-    "name": "lagen om skydd mot olyckor",
-    "type": "law",
-    "alternativeNames": [
-      "LSO"
-    ]
-  },
-  {
-    "id": "2004:168",
-    "name": "smittskyddslagen",
-    "type": "law",
-    "alternativeNames": [
-      "SmittskL"
-    ],
-    "category": "Speciell förvaltningsrätt"
-  },
-  {
-    "id": "2004:347",
-    "name": "prisinformationslagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "Marknadsrätt"
-  },
-  {
-    "id": "2004:451",
-    "name": "produktsäkerhetslagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "Marknadsrätt"
-  },
-  {
-    "id": "2004:519",
-    "name": "järnvägslagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "Speciell förvaltningsrätt"
-  },
-  {
-    "id": "2005:104",
-    "name": "försäkringsavtalslagen",
-    "type": "law",
-    "alternativeNames": [
-      "FAL"
-    ],
-    "category": "Allmän avtalsrätt"
-  },
-  {
-    "id": "2005:403",
-    "name": "naturgaslagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "2005:551",
-    "name": "aktiebolagslagen",
-    "type": "law",
-    "alternativeNames": [
-      "ABL"
-    ],
-    "category": "Associationsrätt"
-  },
-  {
-    "id": "2005:59",
-    "name": "distansavtalslagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "Allmän avtalsrätt"
-  },
-  {
-    "id": "2005:716",
     "name": "utlänningslagen",
     "type": "law",
     "alternativeNames": [
@@ -1576,151 +1159,230 @@
     "category": "Statsrätt"
   },
   {
-    "id": "2005:837",
-    "name": "vallagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "Statsrätt"
-  },
-  {
-    "id": "2006:227",
-    "name": "vägtrafikskattelagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "Skatterätt"
-  },
-  {
-    "id": "2006:304",
-    "name": "rättsprövningslagen",
+    "ids": [
+      "1980:620",
+      "2001:453",
+      "2025:400"
+    ],
+    "name": "socialtjänstlagen",
     "type": "law",
     "alternativeNames": [
-      "RpL",
-      "RättsprL"
+      "SoL"
     ],
-    "category": "Allmän förvaltningsrätt"
+    "category": "Speciell förvaltningsrätt"
   },
   {
-    "id": "2006:548",
-    "name": "skuldsaneringslagen",
+    "ids": [
+      "1980:657"
+    ],
+    "name": "sekretessförordningen",
     "type": "law",
-    "alternativeNames": [],
+    "alternativeNames": [
+      "SekrF"
+    ]
+  },
+  {
+    "ids": [
+      "1981:130"
+    ],
+    "name": "preskriptionslagen",
+    "type": "law",
+    "alternativeNames": [
+      "PreskL"
+    ],
     "category": "Fordringsrätt"
   },
   {
-    "id": "2006:804",
-    "name": "livsmedelslagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "Speciell förvaltningsrätt"
-  },
-  {
-    "id": "2007:612",
-    "name": "bidragsbrottslagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "Straffrätt"
-  },
-  {
-    "id": "2008:263",
-    "name": "fjärrvärmelagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "Speciell förvaltningsrätt"
-  },
-  {
-    "id": "2008:355",
-    "name": "patientdatalagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "IT-rätt"
-  },
-  {
-    "id": "2008:486",
-    "name": "marknadsföringslagen",
-    "type": "law",
-    "alternativeNames": [
-      "MFL"
+    "ids": [
+      "1981:774"
     ],
-    "category": "Marknadsrätt"
-  },
-  {
-    "id": "2008:567",
-    "name": "diskrimineringslagen",
+    "name": "utsökningsbalken",
     "type": "law",
     "alternativeNames": [
-      "DL"
+      "UB"
+    ],
+    "category": "Processrätt"
+  },
+  {
+    "ids": [
+      "1981:981"
+    ],
+    "name": "utsökningsförordningen",
+    "type": "law",
+    "alternativeNames": [
+      "UF"
+    ]
+  },
+  {
+    "ids": [
+      "1982:80"
+    ],
+    "name": "anställningsskyddslagen",
+    "type": "law",
+    "alternativeNames": [
+      "LAS"
     ],
     "category": "Arbetsrätt"
   },
   {
-    "id": "2008:579",
+    "ids": [
+      "1982:670",
+      "2016:1013"
+    ],
+    "name": "namnlagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "Familjerätt"
+  },
+  {
+    "ids": [
+      "1982:673"
+    ],
+    "name": "arbetstidslagen",
+    "type": "law",
+    "alternativeNames": [
+      "ATL"
+    ],
+    "category": "Arbetsrätt"
+  },
+  {
+    "ids": [
+      "1982:713",
+      "2010:2043"
+    ],
+    "name": "försäkringsrörelselagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "Socialrätt"
+  },
+  {
+    "ids": [
+      "1982:729",
+      "1993:20",
+      "2008:579"
+    ],
     "name": "konkurrenslagen",
     "type": "law",
     "alternativeNames": [],
     "category": "Marknadsrätt"
   },
   {
-    "id": "2008:717",
-    "name": "FRA-lagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "Statsrätt"
-  },
-  {
-    "id": "2009:287",
-    "name": "studiestödsdatalagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "IT-rätt"
-  },
-  {
-    "id": "2009:367",
-    "name": "apoteksdatalagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "IT-rätt"
-  },
-  {
-    "id": "2009:400",
-    "name": "offentlighets- och sekretesslagen",
-    "type": "law",
-    "alternativeNames": [
-      "OSL"
+    "ids": [
+      "1982:763",
+      "2017:30"
     ],
-    "category": "Allmän förvaltningsrätt"
-  },
-  {
-    "id": "2009:600",
-    "name": "språklagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "Statsrätt"
-  },
-  {
-    "id": "2009:865",
-    "name": "kommissionslagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "Allmän avtalsrätt"
-  },
-  {
-    "id": "2010:110",
-    "name": "socialförsäkringsbalken",
+    "name": "hälso- och sjukvårdslagen",
     "type": "law",
     "alternativeNames": [
-      "SFB"
+      "HSL"
+    ]
+  },
+  {
+    "ids": [
+      "1982:1011",
+      "1994:1000"
+    ],
+    "name": "lotterilagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "ids": [
+      "1983:929"
+    ],
+    "name": "mönstringslagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "ids": [
+      "1984:292"
+    ],
+    "name": "",
+    "type": "law",
+    "alternativeNames": [
+      "AVLN"
+    ]
+  },
+  {
+    "ids": [
+      "1984:387"
+    ],
+    "name": "polislagen",
+    "type": "law",
+    "alternativeNames": [
+      "PolisL",
+      "PL"
     ],
     "category": "Speciell förvaltningsrätt"
   },
   {
-    "id": "2010:610",
-    "name": "fängelselagen",
+    "ids": [
+      "1985:125"
+    ],
+    "name": "tandvårdslagen",
     "type": "law",
     "alternativeNames": [],
-    "category": "Straffrätt"
+    "category": "Speciell förvaltningsrätt"
   },
   {
-    "id": "2010:900",
+    "ids": [
+      "1985:192",
+      "2018:181"
+    ],
+    "name": "järnvägstrafiklagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "Speciell förvaltningsrätt"
+  },
+  {
+    "ids": [
+      "1985:206"
+    ],
+    "name": "viteslagen",
+    "type": "law",
+    "alternativeNames": [
+      "VitesL"
+    ]
+  },
+  {
+    "ids": [
+      "1985:716"
+    ],
+    "name": "konsumenttjänstlagen",
+    "type": "law",
+    "alternativeNames": [
+      "KTjL"
+    ],
+    "category": "Speciell avtalsrätt"
+  },
+  {
+    "ids": [
+      "1985:1100",
+      "2010:800"
+    ],
+    "name": "skollagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "Speciell förvaltningsrätt"
+  },
+  {
+    "ids": [
+      "1986:223",
+      "2017:900"
+    ],
+    "name": "förvaltningslagen",
+    "type": "law",
+    "alternativeNames": [
+      "FL"
+    ],
+    "category": "Allmän förvaltningsrätt"
+  },
+  {
+    "ids": [
+      "1987:10",
+      "2010:900"
+    ],
     "name": "plan- och bygglagen",
     "type": "law",
     "alternativeNames": [
@@ -1730,23 +1392,996 @@
     "category": "Allmän förvaltningsrätt"
   },
   {
-    "id": "2010:1622",
+    "ids": [
+      "1987:11"
+    ],
+    "name": "",
+    "type": "law",
+    "alternativeNames": [
+      "ESL"
+    ]
+  },
+  {
+    "ids": [
+      "1987:230"
+    ],
+    "name": "äktenskapsbalken",
+    "type": "law",
+    "alternativeNames": [
+      "ÄktB"
+    ],
+    "category": "Familjerätt"
+  },
+  {
+    "ids": [
+      "1987:259"
+    ],
+    "name": "jaktlagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "Speciell förvaltningsrätt"
+  },
+  {
+    "ids": [
+      "1987:619"
+    ],
+    "name": "sparbankslagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "Ekonomisk rätt"
+  },
+  {
+    "ids": [
+      "1987:822"
+    ],
+    "name": "lagen om internationella köp",
+    "type": "law",
+    "alternativeNames": [
+      "CISG"
+    ]
+  },
+  {
+    "ids": [
+      "1987:1065",
+      "1994:1550",
+      "2000:1281",
+      "2016:253"
+    ],
+    "name": "tullagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "Skatterätt"
+  },
+  {
+    "ids": [
+      "1988:49",
+      "2003:364"
+    ],
+    "name": "fartygssäkerhetslagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "Speciell förvaltningsrätt"
+  },
+  {
+    "ids": [
+      "1988:254"
+    ],
+    "name": "knivlagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "Straffrätt"
+  },
+  {
+    "ids": [
+      "1988:360"
+    ],
+    "name": "",
+    "type": "law",
+    "alternativeNames": [
+      "LBH"
+    ]
+  },
+  {
+    "ids": [
+      "1988:534",
+      "2018:1192"
+    ],
+    "name": "djurskyddslagen",
+    "type": "law",
+    "alternativeNames": [
+      "DjurskL"
+    ],
+    "category": "Speciell förvaltningsrätt"
+  },
+  {
+    "ids": [
+      "1988:870"
+    ],
+    "name": "lagen om vård av missbrukare i vissa fall",
+    "type": "law",
+    "alternativeNames": [
+      "LVM"
+    ]
+  },
+  {
+    "ids": [
+      "1988:1604",
+      "2004:451"
+    ],
+    "name": "produktsäkerhetslagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "Marknadsrätt"
+  },
+  {
+    "ids": [
+      "1989:978"
+    ],
+    "name": "prisregleringslagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "ids": [
+      "1990:52"
+    ],
+    "name": "lagen med särskilda bestämmelser om vård av unga",
+    "type": "law",
+    "alternativeNames": [
+      "LVU"
+    ]
+  },
+  {
+    "ids": [
+      "1990:746"
+    ],
+    "name": "lagen om betalningsföreläggande och handräckning",
+    "type": "law",
+    "alternativeNames": [
+      "LBH"
+    ]
+  },
+  {
+    "ids": [
+      "1990:782"
+    ],
+    "name": "arkivlagen",
+    "type": "law",
+    "alternativeNames": [
+      "ArkivL"
+    ],
+    "category": "Allmän förvaltningsrätt"
+  },
+  {
+    "ids": [
+      "1990:931"
+    ],
+    "name": "köplagen",
+    "type": "law",
+    "alternativeNames": [
+      "KöpL"
+    ],
+    "category": "Speciell avtalsrätt"
+  },
+  {
+    "ids": [
+      "1990:1144"
+    ],
+    "name": "begravningslagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "Speciell förvaltningsrätt"
+  },
+  {
+    "ids": [
+      "1991:45"
+    ],
+    "name": "minerallagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "Speciell förvaltningsrätt"
+  },
+  {
+    "ids": [
+      "1991:586"
+    ],
+    "name": "lagen om särskild inkomstskatt för utomlands bosatta",
+    "type": "law",
+    "alternativeNames": [
+      "SINK"
+    ]
+  },
+  {
+    "ids": [
+      "1991:601",
+      "2004:347"
+    ],
+    "name": "prisinformationslagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "Marknadsrätt"
+  },
+  {
+    "ids": [
+      "1991:641"
+    ],
+    "name": "",
+    "type": "law",
+    "alternativeNames": [
+      "BRL"
+    ]
+  },
+  {
+    "ids": [
+      "1991:1128"
+    ],
+    "name": "lagen om psykiatrisk tvångsvård",
+    "type": "law",
+    "alternativeNames": [
+      "LPT"
+    ]
+  },
+  {
+    "ids": [
+      "1991:1129"
+    ],
+    "name": "lagen om rättspsykiatrisk vård",
+    "type": "law",
+    "alternativeNames": [
+      "LRV"
+    ]
+  },
+  {
+    "ids": [
+      "1991:1469"
+    ],
+    "name": "yttrandefrihetsgrundlagen",
+    "type": "law",
+    "alternativeNames": [
+      "YGL"
+    ],
+    "category": "Statsrätt"
+  },
+  {
+    "ids": [
+      "1992:18"
+    ],
+    "name": "produktansvarslagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "Skadeståndsrätt"
+  },
+  {
+    "ids": [
+      "1992:191"
+    ],
+    "name": "",
+    "type": "law",
+    "alternativeNames": [
+      "Avgift"
+    ]
+  },
+  {
+    "ids": [
+      "1992:497"
+    ],
+    "name": "lönegarantilagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "ids": [
+      "1992:859",
+      "2015:315"
+    ],
+    "name": "läkemedelslagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "Speciell förvaltningsrätt"
+  },
+  {
+    "ids": [
+      "1992:1433"
+    ],
+    "name": "sametingslagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "Statsrätt"
+  },
+  {
+    "ids": [
+      "1992:1672",
+      "2018:1217"
+    ],
+    "name": "paketreselagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "Speciell avtalsrätt"
+  },
+  {
+    "ids": [
+      "1992:1685"
+    ],
+    "name": "kulturmiljölagen",
+    "type": "law",
+    "alternativeNames": [
+      "KML"
+    ]
+  },
+  {
+    "ids": [
+      "1993:387"
+    ],
+    "name": "lagen om stöd och service till vissa funktionshindrade",
+    "type": "law",
+    "alternativeNames": [
+      "LSS"
+    ]
+  },
+  {
+    "ids": [
+      "1993:581",
+      "2018:2088"
+    ],
+    "name": "tobakslagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "Speciell förvaltningsrätt"
+  },
+  {
+    "ids": [
+      "1993:787"
+    ],
+    "name": "fiskelagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "Speciell förvaltningsrätt"
+  },
+  {
+    "ids": [
+      "1993:1617"
+    ],
+    "name": "ordningslagen",
+    "type": "law",
+    "alternativeNames": [
+      "OL"
+    ],
+    "category": "Speciell förvaltningsrätt"
+  },
+  {
+    "ids": [
+      "1993:1684",
+      "2010:1045"
+    ],
+    "name": "postlagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "ids": [
+      "1994:193"
+    ],
+    "name": "",
+    "type": "law",
+    "alternativeNames": [
+      "IURF"
+    ]
+  },
+  {
+    "ids": [
+      "1994:200",
+      "2023:200"
+    ],
+    "name": "mervärdesskattelagen",
+    "type": "law",
+    "alternativeNames": [
+      "ML"
+    ],
+    "category": "Skatterätt"
+  },
+  {
+    "ids": [
+      "1994:260"
+    ],
+    "name": "lagen om offentlig anställning",
+    "type": "law",
+    "alternativeNames": [
+      "LOA"
+    ]
+  },
+  {
+    "ids": [
+      "1994:334",
+      "2006:548",
+      "2016:675"
+    ],
+    "name": "skuldsaneringslagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "Fordringsrätt"
+  },
+  {
+    "ids": [
+      "1994:448"
+    ],
+    "name": "",
+    "type": "law",
+    "alternativeNames": [
+      "PbrL"
+    ]
+  },
+  {
+    "ids": [
+      "1994:847"
+    ],
+    "name": "",
+    "type": "law",
+    "alternativeNames": [
+      "BVL"
+    ]
+  },
+  {
+    "ids": [
+      "1994:1219"
+    ],
+    "name": "europakonventionen",
+    "type": "law",
+    "alternativeNames": [
+      "EKMR"
+    ]
+  },
+  {
+    "ids": [
+      "1994:1220"
+    ],
+    "name": "stiftelselagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "Associationsrätt"
+  },
+  {
+    "ids": [
+      "1994:1512"
+    ],
+    "name": "",
+    "type": "law",
+    "alternativeNames": [
+      "AVLK"
+    ]
+  },
+  {
+    "ids": [
+      "1994:1738",
+      "2010:1622"
+    ],
     "name": "alkohollagen",
     "type": "law",
     "alternativeNames": [],
     "category": "Speciell förvaltningsrätt"
   },
   {
-    "id": "2010:1846",
-    "name": "konsumentkreditlagen",
+    "ids": [
+      "1995:400",
+      "2011:666",
+      "2021:516"
+    ],
+    "name": "fastighetsmäklarlagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "Sakrätt"
+  },
+  {
+    "ids": [
+      "1995:584"
+    ],
+    "name": "föräldraledighetslagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "Familjerätt"
+  },
+  {
+    "ids": [
+      "1995:1000"
+    ],
+    "name": "pantbankslagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "Ekonomisk rätt"
+  },
+  {
+    "ids": [
+      "1995:1322"
+    ],
+    "name": "",
     "type": "law",
     "alternativeNames": [
-      "KKrL"
+      "VerksF"
+    ]
+  },
+  {
+    "ids": [
+      "1995:1554"
+    ],
+    "name": "årsredovisningslagen",
+    "type": "law",
+    "alternativeNames": [
+      "ÅRL"
+    ],
+    "category": "Associationsrätt"
+  },
+  {
+    "ids": [
+      "1996:242"
+    ],
+    "name": "ärendelagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "Processrätt"
+  },
+  {
+    "ids": [
+      "1996:627",
+      "2018:585"
+    ],
+    "name": "säkerhetsskyddslagen",
+    "type": "law",
+    "alternativeNames": [
+      "SäkL"
+    ],
+    "category": "Speciell förvaltningsrätt"
+  },
+  {
+    "ids": [
+      "1996:799"
+    ],
+    "name": "patientskadelagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "Skadeståndsrätt"
+  },
+  {
+    "ids": [
+      "1996:1596",
+      "2013:801"
+    ],
+    "name": "bibliotekslagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "Speciell förvaltningsrätt"
+  },
+  {
+    "ids": [
+      "1997:192"
+    ],
+    "name": "",
+    "type": "law",
+    "alternativeNames": [
+      "LIF"
+    ]
+  },
+  {
+    "ids": [
+      "1997:288"
+    ],
+    "name": "elberedskapslagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "ids": [
+      "1997:483"
+    ],
+    "name": "skattebetalningslagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "Skatterätt"
+  },
+  {
+    "ids": [
+      "1997:857"
+    ],
+    "name": "ellagen",
+    "type": "law",
+    "alternativeNames": [
+      "EL"
+    ]
+  },
+  {
+    "ids": [
+      "1998:112"
+    ],
+    "name": "bbs-lagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "IT-rätt"
+  },
+  {
+    "ids": [
+      "1998:204"
+    ],
+    "name": "personuppgiftslagen",
+    "type": "law",
+    "alternativeNames": [
+      "PUL"
+    ],
+    "category": "IT-rätt"
+  },
+  {
+    "ids": [
+      "1998:622",
+      "2010:361"
+    ],
+    "name": "polisdatalagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "IT-rätt"
+  },
+  {
+    "ids": [
+      "1998:674"
+    ],
+    "name": "",
+    "type": "law",
+    "alternativeNames": [
+      "LIP"
+    ]
+  },
+  {
+    "ids": [
+      "1998:808"
+    ],
+    "name": "miljöbalken",
+    "type": "law",
+    "alternativeNames": [
+      "MB"
+    ],
+    "category": "Fastighetsrätt"
+  },
+  {
+    "ids": [
+      "1999:355"
+    ],
+    "name": "kasinolagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "Speciell förvaltningsrätt"
+  },
+  {
+    "ids": [
+      "1999:381"
+    ],
+    "name": "sevesolagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "ids": [
+      "1999:382"
+    ],
+    "name": "sevesoförordningen",
+    "type": "regulation",
+    "alternativeNames": [],
+    "category": "Speciell förvaltningsrätt"
+  },
+  {
+    "ids": [
+      "1999:658"
+    ],
+    "name": "zoonoslagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "ids": [
+      "1999:799"
+    ],
+    "name": "socialförsäkringslagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "Speciell förvaltningsrätt"
+  },
+  {
+    "ids": [
+      "1999:1079"
+    ],
+    "name": "revisionslagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "Associationsrätt"
+  },
+  {
+    "ids": [
+      "1999:1229"
+    ],
+    "name": "inkomstskattelagen",
+    "type": "law",
+    "alternativeNames": [
+      "IL"
+    ],
+    "category": "Skatterätt"
+  },
+  {
+    "ids": [
+      "2000:599",
+      "2005:403"
+    ],
+    "name": "naturgaslagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "ids": [
+      "2000:980"
+    ],
+    "name": "socialavgiftslagen",
+    "type": "law",
+    "alternativeNames": [
+      "SAL"
+    ],
+    "category": "Skatterätt"
+  },
+  {
+    "ids": [
+      "2001:559"
+    ],
+    "name": "vägtrafiklagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "Speciell förvaltningsrätt"
+  },
+  {
+    "ids": [
+      "2001:883"
+    ],
+    "name": "revisorslagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "Associationsrätt"
+  },
+  {
+    "ids": [
+      "2001:1227"
+    ],
+    "name": "lagen om självdeklarationer och kontrolluppgifter",
+    "type": "law",
+    "alternativeNames": [
+      "LSK"
+    ]
+  },
+  {
+    "ids": [
+      "2002:562"
+    ],
+    "name": "e-handelslagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "ids": [
+      "2002:574"
+    ],
+    "name": "fordonslagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "Speciell förvaltningsrätt"
+  },
+  {
+    "ids": [
+      "2003:234"
+    ],
+    "name": "",
+    "type": "law",
+    "alternativeNames": [
+      "Tillhandahållande"
+    ]
+  },
+  {
+    "ids": [
+      "2003:376"
+    ],
+    "name": "sambolagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "Familjerätt"
+  },
+  {
+    "ids": [
+      "2003:389"
+    ],
+    "name": "lagen om elektronisk kommunikation",
+    "type": "law",
+    "alternativeNames": [
+      "LEK"
+    ]
+  },
+  {
+    "ids": [
+      "2003:778"
+    ],
+    "name": "lagen om skydd mot olyckor",
+    "type": "law",
+    "alternativeNames": [
+      "LSO"
+    ]
+  },
+  {
+    "ids": [
+      "2004:519"
+    ],
+    "name": "järnvägslagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "Speciell förvaltningsrätt"
+  },
+  {
+    "ids": [
+      "2005:59"
+    ],
+    "name": "distansavtalslagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "Allmän avtalsrätt"
+  },
+  {
+    "ids": [
+      "2005:104"
+    ],
+    "name": "försäkringsavtalslagen",
+    "type": "law",
+    "alternativeNames": [
+      "FAL"
     ],
     "category": "Allmän avtalsrätt"
   },
   {
-    "id": "2011:1244",
+    "ids": [
+      "2006:227"
+    ],
+    "name": "vägtrafikskattelagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "Skatterätt"
+  },
+  {
+    "ids": [
+      "2006:304"
+    ],
+    "name": "rättsprövningslagen",
+    "type": "law",
+    "alternativeNames": [
+      "RpL",
+      "RättsprL"
+    ],
+    "category": "Allmän förvaltningsrätt"
+  },
+  {
+    "ids": [
+      "2007:612"
+    ],
+    "name": "bidragsbrottslagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "Straffrätt"
+  },
+  {
+    "ids": [
+      "2008:263"
+    ],
+    "name": "fjärrvärmelagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "Speciell förvaltningsrätt"
+  },
+  {
+    "ids": [
+      "2008:355"
+    ],
+    "name": "patientdatalagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "IT-rätt"
+  },
+  {
+    "ids": [
+      "2008:567"
+    ],
+    "name": "diskrimineringslagen",
+    "type": "law",
+    "alternativeNames": [
+      "DL"
+    ],
+    "category": "Arbetsrätt"
+  },
+  {
+    "ids": [
+      "2008:717"
+    ],
+    "name": "FRA-lagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "Statsrätt"
+  },
+  {
+    "ids": [
+      "2009:287"
+    ],
+    "name": "studiestödsdatalagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "IT-rätt"
+  },
+  {
+    "ids": [
+      "2009:367"
+    ],
+    "name": "apoteksdatalagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "IT-rätt"
+  },
+  {
+    "ids": [
+      "2009:400"
+    ],
+    "name": "offentlighets- och sekretesslagen",
+    "type": "law",
+    "alternativeNames": [
+      "OSL"
+    ],
+    "category": "Allmän förvaltningsrätt"
+  },
+  {
+    "ids": [
+      "2009:600"
+    ],
+    "name": "språklagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "Statsrätt"
+  },
+  {
+    "ids": [
+      "2009:865"
+    ],
+    "name": "kommissionslagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "Allmän avtalsrätt"
+  },
+  {
+    "ids": [
+      "2010:110"
+    ],
+    "name": "socialförsäkringsbalken",
+    "type": "law",
+    "alternativeNames": [
+      "SFB"
+    ],
+    "category": "Speciell förvaltningsrätt"
+  },
+  {
+    "ids": [
+      "2010:610"
+    ],
+    "name": "fängelselagen",
+    "type": "law",
+    "alternativeNames": [],
+    "category": "Straffrätt"
+  },
+  {
+    "ids": [
+      "2011:1029"
+    ],
+    "name": "",
+    "type": "law",
+    "alternativeNames": [
+      "LUFS"
+    ]
+  },
+  {
+    "ids": [
+      "2011:1244"
+    ],
     "name": "skatteförfarandelagen",
     "type": "law",
     "alternativeNames": [
@@ -1755,7 +2390,9 @@
     "category": "Skatterätt"
   },
   {
-    "id": "2013:561",
+    "ids": [
+      "2013:561"
+    ],
     "name": "lagen om förvaltare av alternativa investeringsfonder",
     "type": "law",
     "alternativeNames": [
@@ -1763,14 +2400,9 @@
     ]
   },
   {
-    "id": "2015:315",
-    "name": "läkemedelslagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "Speciell förvaltningsrätt"
-  },
-  {
-    "id": "2016:1145",
+    "ids": [
+      "2016:1145"
+    ],
     "name": "lagen om offentlig upphandling",
     "type": "law",
     "alternativeNames": [
@@ -1778,24 +2410,37 @@
     ]
   },
   {
-    "id": "2017:30",
-    "name": "hälso- och sjukvårdslagen",
+    "ids": [
+      "2016:1146"
+    ],
+    "name": "",
     "type": "law",
     "alternativeNames": [
-      "HSL"
+      "LUF"
     ]
   },
   {
-    "id": "2017:900",
-    "name": "förvaltningslagen",
+    "ids": [
+      "2016:1147"
+    ],
+    "name": "",
     "type": "law",
     "alternativeNames": [
-      "FL"
-    ],
-    "category": "Allmän förvaltningsrätt"
+      "LUK"
+    ]
   },
   {
-    "id": "2018:218",
+    "ids": [
+      "2017:630"
+    ],
+    "name": "penningtvättslagen",
+    "type": "law",
+    "alternativeNames": []
+  },
+  {
+    "ids": [
+      "2018:218"
+    ],
     "name": "dataskyddslagen",
     "type": "law",
     "alternativeNames": [
@@ -1804,530 +2449,9 @@
     "category": "IT-rätt"
   },
   {
-    "id": "2018:1174",
-    "name": "cybersäkerhetslagen",
-    "type": "law",
-    "alternativeNames": [],
-    "category": "IT-rätt"
-  },
-  {
-    "id": "1891:35 s.1",
-    "name": "sjölagen",
-    "type": "law",
-    "alternativeNames": [
-      "SjöL"
-    ]
-  },
-  {
-    "id": "1904:48 s.1",
-    "name": "samäganderättslagen",
-    "type": "law",
-    "alternativeNames": [
-      "SamägL"
-    ]
-  },
-  {
-    "id": "1921:225",
-    "name": "konkurslagen",
-    "type": "law",
-    "alternativeNames": [
-      "KonkL"
-    ]
-  },
-  {
-    "id": "1956:623",
-    "name": "taxeringslagen",
-    "type": "law",
-    "alternativeNames": [
-      "TaxL"
-    ]
-  },
-  {
-    "id": "1958:110",
-    "name": "strålskyddslagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "1967:198",
-    "name": "folkbokföringslagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "1968:231",
-    "name": "smittskyddslagen",
-    "type": "law",
-    "alternativeNames": [
-      "SmittskL"
-    ]
-  },
-  {
-    "id": "1971:392",
-    "name": "växtförädlarrättslagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "1971:479",
-    "name": "bostadsrättslagen",
-    "type": "law",
-    "alternativeNames": [
-      "BRL"
-    ]
-  },
-  {
-    "id": "1971:511",
-    "name": "livsmedelslagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "1972:429",
-    "name": "rättshjälpslagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "1972:620",
-    "name": "vallagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "1973:349",
-    "name": "studiestödslagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "1973:877",
-    "name": "konsumentköplagen",
-    "type": "law",
-    "alternativeNames": [
-      "KKöpL"
-    ]
-  },
-  {
-    "id": "1973:1176",
-    "name": "vapenlagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "1974:358",
-    "name": "förtroendemannalagen",
-    "type": "law",
-    "alternativeNames": [
-      "FML"
-    ]
-  },
-  {
-    "id": "1975:1385",
-    "name": "aktiebolagslagen",
-    "type": "law",
-    "alternativeNames": [
-      "ABL"
-    ]
-  },
-  {
-    "id": "1975:1418",
-    "name": "marknadsföringslagen",
-    "type": "law",
-    "alternativeNames": [
-      "MFL"
-    ]
-  },
-  {
-    "id": "1976:125",
-    "name": "bokföringslagen",
-    "type": "law",
-    "alternativeNames": [
-      "BFL"
-    ]
-  },
-  {
-    "id": "1976:511",
-    "name": "",
-    "type": "law",
-    "alternativeNames": [
-      "LOB"
-    ]
-  },
-  {
-    "id": "1977:179",
-    "name": "kommunallagen",
-    "type": "law",
-    "alternativeNames": [
-      "KL",
-      "KomL"
-    ]
-  },
-  {
-    "id": "1977:218",
-    "name": "högskolelagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "1977:477",
-    "name": "körkortslagen",
-    "type": "law",
-    "alternativeNames": [
-      "KörkL"
-    ]
-  },
-  {
-    "id": "1977:722",
-    "name": "körkortsförordningen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "1977:981",
-    "name": "konsumentkreditlagen",
-    "type": "law",
-    "alternativeNames": [
-      "KKrL"
-    ]
-  },
-  {
-    "id": "1979:559",
-    "name": "yrkestrafiklagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "1980:369",
-    "name": "epizootilagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "1980:376",
-    "name": "utlänningslagen",
-    "type": "law",
-    "alternativeNames": [
-      "UtlL"
-    ]
-  },
-  {
-    "id": "1980:620",
-    "name": "socialtjänstlagen",
-    "type": "law",
-    "alternativeNames": [
-      "SoL"
-    ]
-  },
-  {
-    "id": "1982:729",
-    "name": "konkurrenslagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "1982:763",
-    "name": "hälso- och sjukvårdslagen",
-    "type": "law",
-    "alternativeNames": [
-      "HSL"
-    ]
-  },
-  {
-    "id": "1982:1011",
-    "name": "lotterilagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "1986:223",
-    "name": "förvaltningslagen",
-    "type": "law",
-    "alternativeNames": [
-      "FL"
-    ]
-  },
-  {
-    "id": "1987:10",
-    "name": "plan- och bygglagen",
-    "type": "law",
-    "alternativeNames": [
-      "PBL"
-    ]
-  },
-  {
-    "id": "1987:1065",
-    "name": "tullagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "1988:49",
-    "name": "fartygssäkerhetslagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "1988:263",
-    "name": "yrkestrafiklagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "1988:360",
-    "name": "",
-    "type": "law",
-    "alternativeNames": [
-      "LBH"
-    ]
-  },
-  {
-    "id": "1988:1472",
-    "name": "smittskyddslagen",
-    "type": "law",
-    "alternativeNames": [
-      "SmittskL"
-    ]
-  },
-  {
-    "id": "1988:1604",
-    "name": "produktsäkerhetslagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "1989:529",
-    "name": "utlänningslagen",
-    "type": "law",
-    "alternativeNames": [
-      "UtlL"
-    ]
-  },
-  {
-    "id": "1991:601",
-    "name": "prisinformationslagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "1992:830",
-    "name": "konsumentkreditlagen",
-    "type": "law",
-    "alternativeNames": [
-      "KKrL"
-    ]
-  },
-  {
-    "id": "1992:859",
-    "name": "läkemedelslagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "1993:20",
-    "name": "konkurrenslagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "1994:334",
-    "name": "skuldsaneringslagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "1994:1219",
-    "name": "europakonventionen",
-    "type": "law",
-    "alternativeNames": [
-      "EKMR"
-    ]
-  },
-  {
-    "id": "1994:1550",
-    "name": "tullagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "1994:1738",
-    "name": "alkohollagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "1995:450",
-    "name": "marknadsföringslagen",
-    "type": "law",
-    "alternativeNames": [
-      "MFL"
-    ]
-  },
-  {
-    "id": "1997:157",
-    "name": "vallagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "2000:599",
-    "name": "naturgaslagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "2002:562",
-    "name": "e-handelslagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "2010:361",
-    "name": "polisdatalagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "2010:500",
-    "name": "luftfartslagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "2010:800",
-    "name": "skollagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "2010:1045",
-    "name": "postlagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "2010:1877",
-    "name": "varumärkeslagen",
-    "type": "law",
-    "alternativeNames": [
-      "VML"
-    ]
-  },
-  {
-    "id": "2010:1932",
-    "name": "delgivningslagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "2010:2043",
-    "name": "försäkringsrörelselagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "2011:666",
-    "name": "fastighetsmäklarlagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "2011:1029",
-    "name": "",
-    "type": "law",
-    "alternativeNames": [
-      "LUFS"
-    ]
-  },
-  {
-    "id": "2012:210",
-    "name": "yrkestrafiklagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "2013:801",
-    "name": "bibliotekslagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "2014:322",
-    "name": "brottsskadelagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "2014:801",
-    "name": "riksdagsordningen",
-    "type": "law",
-    "alternativeNames": [
-      "RO"
-    ]
-  },
-  {
-    "id": "2016:253",
-    "name": "tullagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "2016:675",
-    "name": "skuldsaneringslagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "2016:1013",
-    "name": "namnlagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "2016:1146",
-    "name": "",
-    "type": "law",
-    "alternativeNames": [
-      "LUF"
-    ]
-  },
-  {
-    "id": "2016:1147",
-    "name": "",
-    "type": "law",
-    "alternativeNames": [
-      "LUK"
-    ]
-  },
-  {
-    "id": "2017:630",
-    "name": "penningtvättslagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "2017:725",
-    "name": "kommunallagen",
-    "type": "law",
-    "alternativeNames": [
-      "KL",
-      "KomL"
-    ]
-  },
-  {
-    "id": "2018:181",
-    "name": "järnvägstrafiklagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "2018:396",
-    "name": "strålskyddslagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "2018:558",
+    "ids": [
+      "2018:558"
+    ],
     "name": "företagshemlighetslagen",
     "type": "law",
     "alternativeNames": [
@@ -2335,81 +2459,58 @@
     ]
   },
   {
-    "id": "2018:585",
-    "name": "säkerhetsskyddslagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "2018:1138",
+    "ids": [
+      "2018:1138"
+    ],
     "name": "spellagen",
     "type": "law",
     "alternativeNames": []
   },
   {
-    "id": "2018:1192",
-    "name": "djurskyddslagen",
+    "ids": [
+      "2018:1174"
+    ],
+    "name": "cybersäkerhetslagen",
     "type": "law",
-    "alternativeNames": []
+    "alternativeNames": [],
+    "category": "IT-rätt"
   },
   {
-    "id": "2018:1197",
+    "ids": [
+      "2018:1197"
+    ],
     "name": "barnkonventionen",
     "type": "law",
     "alternativeNames": []
   },
   {
-    "id": "2018:1200",
+    "ids": [
+      "2018:1200"
+    ],
     "name": "kamerabevakningslagen",
     "type": "law",
     "alternativeNames": []
   },
   {
-    "id": "2018:1217",
-    "name": "paketreselagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "2018:1218",
-    "name": "resegarantilagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "2018:1653",
+    "ids": [
+      "2018:1653"
+    ],
     "name": "företagsnamnslagen",
     "type": "law",
     "alternativeNames": []
   },
   {
-    "id": "2018:2088",
-    "name": "tobakslagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "2021:516",
-    "name": "fastighetsmäklarlagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "2021:890",
+    "ids": [
+      "2021:890"
+    ],
     "name": "visselblåsarlagen",
     "type": "law",
     "alternativeNames": []
   },
   {
-    "id": "2022:260",
-    "name": "konsumentköplagen",
-    "type": "law",
-    "alternativeNames": [
-      "KKöpL"
-    ]
-  },
-  {
-    "id": "2022:482",
+    "ids": [
+      "2022:482"
+    ],
     "name": "",
     "type": "law",
     "alternativeNames": [
@@ -2417,51 +2518,11 @@
     ]
   },
   {
-    "id": "2022:666",
+    "ids": [
+      "2022:666"
+    ],
     "name": "terroristbrottslagen",
     "type": "law",
     "alternativeNames": []
-  },
-  {
-    "id": "2022:725",
-    "name": "växtskyddslagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "2023:200",
-    "name": "mervärdesskattelagen",
-    "type": "law",
-    "alternativeNames": [
-      "ML"
-    ]
-  },
-  {
-    "id": "2024:945",
-    "name": "patentlagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "2025:400",
-    "name": "socialtjänstlagen",
-    "type": "law",
-    "alternativeNames": [
-      "SoL"
-    ]
-  },
-  {
-    "id": "2026:408",
-    "name": "vapenlagen",
-    "type": "law",
-    "alternativeNames": []
-  },
-  {
-    "id": "2026:1011",
-    "name": "konsumentkreditlagen",
-    "type": "law",
-    "alternativeNames": [
-      "KKrL"
-    ]
   }
 ]

--- a/formatters/apply_links.py
+++ b/formatters/apply_links.py
@@ -295,7 +295,18 @@ def apply_law_name_links(text: str) -> str:
 def _load_law_names():
     """
     Laddar lagnamn från data/law-names.json.
-    
+
+    Ett lagnamn kan över tid ha burits av flera författningar i följd
+    (t.ex. "patentlagen" = 1967:837 fram till 2025-01-01, därefter 2024:945),
+    så varje post har en kronologiskt sorterad lista `ids`. Utan ett
+    referensdatum att slå upp mot väljer vi den senaste (nuvarande) lagen i
+    listan.
+
+    TODO: när ids > 1, slå istället upp mot respektive lags egna
+    upphavdDateTime/ikraftDateTime (källdata som redan laddas ner) för att
+    välja rätt id för det datum referensen faktiskt gäller, istället för att
+    alltid anta att den senaste är rätt.
+
     Returns:
         dict: Dictionary med lagnamn som nycklar och SFS-ID som värden, eller None om fel
     """
@@ -304,22 +315,22 @@ def _load_law_names():
         current_file = Path(__file__)
         project_root = current_file.parent.parent  # från formatters/ till projektrot
         law_names_file = project_root / "data" / "law-names.json"
-        
+
         if not law_names_file.exists():
             print(f"Varning: Kunde inte hitta {law_names_file}")
             return None
-            
+
         with open(law_names_file, 'r', encoding='utf-8') as f:
             law_data = json.load(f)
-        
-        # Skapa lookup-dictionary: lagnamn -> SFS-ID
+
+        # Skapa lookup-dictionary: lagnamn -> SFS-ID (senaste av eventuellt flera)
         law_lookup = {}
         for entry in law_data:
-            if entry.get('name'):
-                law_lookup[entry['name'].lower()] = entry['id']
-        
+            if entry.get('name') and entry.get('ids'):
+                law_lookup[entry['name'].lower()] = entry['ids'][-1]
+
         return law_lookup
-        
+
     except Exception as e:
         print(f"Fel vid laddning av lagnamn: {e}")
         return None

--- a/scripts/validate_law_names.py
+++ b/scripts/validate_law_names.py
@@ -21,11 +21,11 @@ def load_law_names(json_file_path):
         with open(json_file_path, 'r', encoding='utf-8') as f:
             law_data = json.load(f)
         
-        # Create lookup dictionary: lagnamn -> SFS-ID
+        # Create lookup dictionary: lagnamn -> SFS-ID (senaste av eventuellt flera ids)
         law_lookup = {}
         for entry in law_data:
-            if entry.get('name'):
-                law_lookup[entry['name'].lower()] = entry['id']
+            if entry.get('name') and entry.get('ids'):
+                law_lookup[entry['name'].lower()] = entry['ids'][-1]
         
         return law_lookup, law_data
         


### PR DESCRIPTION
Lagar utan kategori är svårare att filtrera och söka på. Kategoriserar 26 lagar inom arbetsrätt, skatterätt, processrätt, statsrätt m.fl.

Tar även bort dubblettposten för 2009:400 ("sekretesslagen") som är en kopia av "offentlighets- och sekretesslagen" med samma id och förkortning.