### PR TITLE
Prototype: git fast-import based git export

### DIFF
--- a/exporters/git/__init__.py
+++ b/exporters/git/__init__.py
@@ -1,29 +1,35 @@
 """Git export functionality for SFS documents."""
 
+from .generate_commits import (
+    InitCommitPlan,
+    TemporalCommitPlan,
+    create_init_git_commit,
+    plan_init_commit,
+    plan_temporal_commits,
+)
 from .git_utils import (
-    prepare_git_branch, 
-    restore_original_branch, 
-    remove_all_commits_on_branch,
-    get_target_repository,
-    configure_git_remote,
-    push_to_target_repository,
-    clone_target_repository_to_temp,
-    is_file_tracked,
-    has_staged_changes,
-    stage_file,
     check_duplicate_commit_message,
-    create_commit_with_date
+    clone_target_repository_to_temp,
+    configure_git_remote,
+    create_commit_with_date,
+    get_target_repository,
+    has_staged_changes,
+    is_file_tracked,
+    prepare_git_branch,
+    push_to_target_repository,
+    remove_all_commits_on_branch,
+    restore_original_branch,
+    stage_file,
 )
 from .init_commits_batch_processor import process_files_with_git_batch
 from .temporal_commits_batch_processor import process_temporal_commits_batch
-from .generate_commits import create_init_git_commit
 
 __all__ = [
-    'prepare_git_branch', 
-    'restore_original_branch', 
+    'prepare_git_branch',
+    'restore_original_branch',
     'remove_all_commits_on_branch',
     'get_target_repository',
-    'configure_git_remote', 
+    'configure_git_remote',
     'push_to_target_repository',
     'clone_target_repository_to_temp',
     'is_file_tracked',
@@ -33,5 +39,9 @@ __all__ = [
     'create_commit_with_date',
     'process_files_with_git_batch',
     'process_temporal_commits_batch',
-    'create_init_git_commit'
+    'create_init_git_commit',
+    'plan_init_commit',
+    'plan_temporal_commits',
+    'InitCommitPlan',
+    'TemporalCommitPlan',
 ]

--- a/exporters/git/fast_import_export.py
+++ b/exporters/git/fast_import_export.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""Fast-import based export pipeline — an alternative to `batch_export_to_git.py`.
+
+`batch_export_to_git.py` creates every commit via `git add` / `git commit`
+subprocess calls: once per document for initial commits, once per date per
+document for temporal (ikraft/upphör) commits, across two separate
+porcelain-driven passes. Each of those calls rewrites the index and touches
+the working tree, which dominates wall-clock time once you're generating on
+the order of tens of thousands of commits (see ADR-003 and `sfs_processor.py`
+`--formats git`, where SFS has ~50 000 författningar).
+
+This module instead:
+
+  1. Computes every commit's plan (path, content, message, date) up front,
+     for every document, by reusing the exact same content-generation logic
+     as the subprocess-based exporter (`generate_commits.plan_init_commit`
+     / `plan_temporal_commits`) — no legal-content logic is duplicated.
+  2. Sorts all of those plans, across ALL documents, into one single
+     chronological sequence.
+  3. Streams them through one `git fast-import` invocation, which builds the
+     commits directly in the object database — no working tree, no index,
+     no per-commit subprocess call, no branch checkout.
+
+A side effect of step 2 is a genuine improvement in history shape: because
+every commit (initial + temporal, across every document) is globally
+date-sorted before being written, the branch's parent chain matches real
+chronological order — rather than being grouped document-by-document with
+backdated timestamps layered on top of creation order, as the current
+exporter produces (still visually chronological in `git log`, since that
+sorts by date regardless of parent order, but the underlying graph isn't).
+
+Usage:
+    python -m exporters.git.fast_import_export --years 2024-2026 --branch fast-import-2025-12-28
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from exporters.git.fast_import_writer import FastImportWriter, FileChange, to_raw_git_date
+from exporters.git.generate_commits import plan_init_commit, plan_temporal_commits
+from exporters.git.git_utils import GIT_TIMEOUT, clone_target_repository_to_temp, push_to_target_repository
+from formatters.frontmatter_manager import extract_frontmatter_property
+from temporal.upcoming_changes import identify_upcoming_changes
+from util.file_utils import filter_json_files, read_file_content, save_to_disk
+
+
+@dataclass
+class CommitEvent:
+    """One globally-ordered commit: a full rewrite of a single file's content."""
+
+    date: str  # ISO date, e.g. "2010-01-15"
+    message: str
+    path: str  # repo-relative path, e.g. "2010/sfs-2010-100.md"
+    content: str
+
+
+def _init_commit_events(json_files: list[Path], output_dir: Path | None, verbose: bool) -> list[CommitEvent]:
+    """Build one CommitEvent per document's initial (utfärdande) commit."""
+    # Deferred import: sfs_processor imports from exporters.git at module
+    # level, so importing it back at *this* module's top level would be
+    # circular. By the time this function runs, sfs_processor is fully
+    # loaded — same pattern as init_commits_batch_processor.py.
+    from formatters.format_sfs_text import normalize_heading_levels
+    from sfs_processor import convert_to_markdown, create_id_slug, create_safe_filename
+
+    events = []
+    for json_file in json_files:
+        try:
+            data = json.loads(read_file_content(json_file))
+        except (OSError, json.JSONDecodeError) as e:
+            print(f"Fel vid läsning av {json_file}: {e}")
+            continue
+
+        markdown_content = convert_to_markdown(data, fetch_predocs_from_api=False, apply_links=True)
+        markdown_content = normalize_heading_levels(markdown_content)
+
+        try:
+            plan = plan_init_commit(data, markdown_content, verbose)
+        except ValueError as e:
+            print(f"Fel vid planering av {json_file}: {e}")
+            continue
+
+        id_slug = create_id_slug(data.get("beteckningSortable", plan.beteckning))
+        filename = create_safe_filename(id_slug, preserve_selex_tags=False)
+        relative_path = Path(plan.year) / filename if plan.year else Path(filename)
+
+        if output_dir is not None:
+            reference_file = output_dir / relative_path
+            reference_file.parent.mkdir(parents=True, exist_ok=True)
+            save_to_disk(reference_file, plan.content)
+
+        events.append(
+            CommitEvent(
+                date=plan.commit_date, message=plan.commit_message, path=str(relative_path), content=plan.content
+            )
+        )
+
+    return events
+
+
+def _temporal_commit_events(markdown_dir: Path, from_date: str | None, to_date: str | None) -> list[CommitEvent]:
+    """Build one CommitEvent per date with temporal changes, per document.
+
+    Mirrors the path convention in `temporal_commits_batch_processor.py`:
+    the file lands at `<year>/<name-without-"-markers">.md`, where `<year>`
+    is the marker file's parent directory name.
+    """
+    events = []
+    for md_file in sorted(markdown_dir.rglob("*.md")):
+        try:
+            content = read_file_content(md_file)
+        except OSError as e:
+            print(f"Fel vid läsning av {md_file}: {e}")
+            continue
+
+        if "<article" not in content:
+            continue  # no selex tags left, nothing temporal to extract
+
+        changes = identify_upcoming_changes(content)
+        if not changes:
+            continue
+
+        changes_by_date: dict[str, list] = {}
+        for change in changes:
+            change_date = change["date"]
+            if from_date and change_date < from_date:
+                continue
+            if to_date and change_date > to_date:
+                continue
+            changes_by_date.setdefault(change_date, []).append(change)
+
+        if not changes_by_date:
+            continue
+
+        doc_name = extract_frontmatter_property(content, "beteckning")
+        rubrik = extract_frontmatter_property(content, "rubrik")
+        if not doc_name:
+            print(f"Varning: Ingen doc_name hittades i frontmatter för {md_file}")
+            continue
+
+        year_dir = md_file.parent.name
+        filename = md_file.name.replace("-markers", "")
+        relative_path = Path(year_dir) / filename
+
+        for plan in plan_temporal_commits(content, doc_name, rubrik, changes_by_date):
+            events.append(
+                CommitEvent(date=plan.date, message=plan.message, path=str(relative_path), content=plan.content)
+            )
+
+    return events
+
+
+def _resolve_ref(repo_dir: Path, ref: str) -> str | None:
+    """Resolve `ref` to a commit sha in `repo_dir`, or None if it doesn't exist."""
+    result = subprocess.run(
+        ["git", "rev-parse", "--verify", ref], cwd=repo_dir, capture_output=True, text=True, timeout=GIT_TIMEOUT
+    )
+    return result.stdout.strip() if result.returncode == 0 else None
+
+
+def export_to_git_fast_import(
+    json_files: list[Path],
+    markers_dir: Path | None,
+    branch_name: str,
+    output_dir: Path | None = None,
+    from_date: str | None = None,
+    to_date: str | None = None,
+    base_ref: str = "refs/heads/main",
+    verbose: bool = False,
+) -> int:
+    """Generate the full SFS git export (initial + temporal commits) as one
+    globally date-sorted `git fast-import` stream, then push once.
+
+    Returns the number of commits written.
+    """
+    repo_dir, _original_cwd = clone_target_repository_to_temp(verbose=verbose)
+    if repo_dir is None:
+        raise RuntimeError("Failed to clone target repository")
+
+    print(f"Bygger commit-plan för {len(json_files)} dokument...")
+    events = _init_commit_events(json_files, output_dir, verbose)
+
+    if markers_dir is not None and markers_dir.exists():
+        print(f"Bygger temporal commit-plan från {markers_dir}...")
+        events += _temporal_commit_events(markers_dir, from_date, to_date)
+
+    if not events:
+        print("Inga commits att generera.")
+        return 0
+
+    # Global chronological order across every document — the point of doing
+    # this in one fast-import pass instead of per-document porcelain commits.
+    events.sort(key=lambda e: (e.date, e.path))
+    print(f"Totalt {len(events)} commits, sorterade kronologiskt {events[0].date} .. {events[-1].date}")
+
+    from_ref = _resolve_ref(repo_dir, base_ref) if base_ref else None
+    if base_ref and verbose:
+        print(
+            f"Ny branch rotas i {base_ref} ({from_ref})" if from_ref else f"{base_ref} finns inte, skapar rot-historik"
+        )
+
+    writer = FastImportWriter.to_repo(repo_dir, verbose=verbose)
+    for i, event in enumerate(events):
+        raw_date = to_raw_git_date(event.date)
+        writer.commit(
+            branch=branch_name,
+            message=event.message,
+            author_date=raw_date,
+            committer_date=raw_date,
+            changes=[FileChange.write(event.path, event.content)],
+            from_ref=from_ref if i == 0 else None,
+        )
+        if verbose and (i + 1) % 1000 == 0:
+            print(f"  ... {i + 1}/{len(events)} commits skrivna")
+
+    writer.close()
+    print(f"✅ {writer.commit_count} commits skapade i branch '{branch_name}' (en enda fast-import-pass)")
+
+    if not push_to_target_repository(branch_name, "origin", verbose):
+        raise RuntimeError(f"Misslyckades med att pusha branch '{branch_name}'")
+
+    print(f"✅ Branch '{branch_name}' pushad till target repository")
+    return writer.commit_count
+
+
+def main() -> int:
+    from exporters.git.batch_export_to_git import parse_year_range, year_range_to_date_range
+
+    parser = argparse.ArgumentParser(
+        description="Exportera SFS-dokument till Git via en enda git-fast-import-ström (prototyp, se ADR-003)."
+    )
+    parser.add_argument("--years", help='Årsintervall att exportera (t.ex. "2024-2026" eller "2024").')
+    parser.add_argument("--filter", help="Filtrera filer på år (YYYY) eller beteckning (YYYY:NNN), kommaseparerat.")
+    parser.add_argument("--branch", required=True, help="Git-branchnamn att skapa commits på.")
+    parser.add_argument("--input", "-i", help="Katalog med JSON-filer (default: ../sfs-jsondata)")
+    parser.add_argument("--output", "-o", help="Katalog för lokala referenskopior (utelämna för att hoppa över)")
+    parser.add_argument("--markers-dir", help="Katalog med markdown-filer med selex-markers för temporal commits")
+    parser.add_argument(
+        "--base-ref", default="refs/heads/main", help="Ref att rota exportbranchen i (default: refs/heads/main)"
+    )
+    parser.add_argument("--verbose", action="store_true", help="Visa detaljerad output")
+
+    args = parser.parse_args()
+
+    script_dir = Path(__file__).parent
+    json_dir = Path(args.input) if args.input else script_dir.parent / "sfs-jsondata"
+    output_dir = Path(args.output) if args.output else None
+    markers_dir = Path(args.markers_dir) if args.markers_dir else script_dir.parent / "sfs-export-md-markers"
+
+    if not json_dir.exists():
+        print(f"Fel: JSON-katalog {json_dir} finns inte")
+        return 1
+
+    json_files = list(json_dir.glob("*.json"))
+    if not json_files:
+        print(f"Inga JSON-filer hittades i {json_dir}")
+        return 1
+
+    filter_str = None
+    from_date = to_date = None
+    if args.years:
+        years = parse_year_range(args.years)
+        filter_str = ",".join(years)
+        from_date, to_date = year_range_to_date_range(args.years)
+    elif args.filter:
+        filter_str = args.filter
+
+    if filter_str:
+        original_count = len(json_files)
+        json_files = filter_json_files(json_files, filter_str)
+        print(f"Filter '{filter_str}' tillämpad: {len(json_files)} av {original_count} filer valda")
+        if not json_files:
+            print("Inga filer matchar filterkriterier")
+            return 1
+
+    try:
+        export_to_git_fast_import(
+            json_files=json_files,
+            markers_dir=markers_dir,
+            branch_name=args.branch,
+            output_dir=output_dir,
+            from_date=from_date,
+            to_date=to_date,
+            base_ref=args.base_ref,
+            verbose=args.verbose,
+        )
+    except Exception as e:
+        print(f"❌ Fel vid fast-import-export: {e}")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/exporters/git/fast_import_writer.py
+++ b/exporters/git/fast_import_writer.py
@@ -1,0 +1,168 @@
+"""Writer for the git-fast-import stream format.
+
+`git fast-import` builds commits directly into the object database from a
+single stdin stream, without ever touching the working tree or the index.
+For a history that is generated wholesale from another data source (like the
+SFS git export, which backdates every commit) that avoids the per-commit
+`git add` / `git commit` subprocess overhead of the porcelain-based exporter
+in `generate_commits.py` / `git_utils.py`.
+
+Only the subset of the fast-import grammar SFS export needs is implemented:
+commits with inline file blobs on a single branch, in strictly increasing
+commit order, optionally rooted onto an existing branch tip via `from`.
+
+See `git help fast-import` for the full protocol.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import BinaryIO
+from zoneinfo import ZoneInfo
+
+# Swedish legislation dates are inherently Swedish local time; converting via
+# this zone (rather than relying on the exporting machine's local timezone,
+# as the current GIT_AUTHOR_DATE-env-var approach implicitly does) keeps DST
+# offsets correct and makes the result independent of where export runs.
+SFS_TIMEZONE = ZoneInfo("Europe/Stockholm")
+
+DEFAULT_COMMIT_TIME = "00:00:00"
+
+
+@dataclass
+class FileChange:
+    """A single file's content at a commit. `content is None` means delete."""
+
+    path: str
+    content: bytes | None
+
+    @classmethod
+    def write(cls, path: str, content: str) -> FileChange:
+        return cls(path=path, content=content.encode("utf-8"))
+
+    @classmethod
+    def delete(cls, path: str) -> FileChange:
+        return cls(path=path, content=None)
+
+
+def to_raw_git_date(iso_date: str, time_str: str = DEFAULT_COMMIT_TIME, tz: ZoneInfo = SFS_TIMEZONE) -> str:
+    """Convert a 'YYYY-MM-DD' date into fast-import's raw date format.
+
+    Raw format is '<seconds-since-epoch> <+/-HHMM>', which is what
+    `git fast-import` expects by default for `author`/`committer` lines.
+    """
+    naive = datetime.fromisoformat(f"{iso_date}T{time_str}")
+    aware = naive.replace(tzinfo=tz)
+    epoch = int(aware.timestamp())
+    offset_minutes = int(aware.utcoffset().total_seconds() // 60)
+    sign = "+" if offset_minutes >= 0 else "-"
+    offset_minutes = abs(offset_minutes)
+    return f"{epoch} {sign}{offset_minutes // 60:02d}{offset_minutes % 60:02d}"
+
+
+def _quote_path(path: str) -> str:
+    """Quote a path per fast-import's C-style path quoting.
+
+    Always quoting (rather than only when a special character is present)
+    is valid per the grammar and avoids having to special-case spaces, etc.
+    """
+    escaped = path.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+class FastImportWriter:
+    """Writes a git-fast-import stream to a live `git fast-import` process
+    (or, for inspection/testing, to a plain file)."""
+
+    def __init__(self, stream: BinaryIO, process: subprocess.Popen | None = None):
+        self._stream = stream
+        self._process = process
+        self._commit_count = 0
+
+    @classmethod
+    def to_repo(cls, repo_dir: Path, verbose: bool = False) -> FastImportWriter:
+        """Start `git fast-import` inside `repo_dir`, fed via its stdin.
+
+        The resulting commits land as real refs in `repo_dir`'s object
+        database as soon as `close()` returns successfully — no checkout or
+        `git add` involved.
+        """
+        process = subprocess.Popen(
+            ["git", "fast-import", "--stats" if verbose else "--quiet"],
+            cwd=repo_dir,
+            stdin=subprocess.PIPE,
+        )
+        return cls(process.stdin, process)
+
+    @classmethod
+    def to_file(cls, path: Path) -> FastImportWriter:
+        """Write the stream to a plain file instead of a live process.
+
+        Useful to inspect a generated stream, or to feed it into
+        `git fast-import` later by hand (`git fast-import < path`).
+        """
+        return cls(open(path, "wb"))
+
+    def _write_text(self, text: str) -> None:
+        self._stream.write(text.encode("utf-8"))
+
+    def _write_data(self, content: bytes) -> None:
+        self._write_text(f"data {len(content)}\n")
+        self._stream.write(content)
+        # Trailing LF is optional per the grammar but recommended when the
+        # raw data doesn't already end in one; harmless either way.
+        self._write_text("\n")
+
+    def commit(
+        self,
+        branch: str,
+        message: str,
+        author_date: str,
+        committer_date: str,
+        changes: list[FileChange],
+        author_name: str = "SFS Processor",
+        author_email: str = "sfs-processor@localhost",
+        from_ref: str | None = None,
+    ) -> None:
+        """Emit one commit onto `refs/heads/<branch>`.
+
+        `author_date`/`committer_date` must already be in fast-import's raw
+        format (see `to_raw_git_date`). `from_ref` should only be passed for
+        the very first commit written to a given branch in this stream —
+        subsequent commits on the same branch chain automatically. Pass it
+        when the branch should start from an existing commit (e.g. the
+        target repo's `main` tip) rather than as a fresh root commit.
+        """
+        self._write_text(f"commit refs/heads/{branch}\n")
+        self._write_text(f"author {author_name} <{author_email}> {author_date}\n")
+        self._write_text(f"committer {author_name} <{author_email}> {committer_date}\n")
+        self._write_data(message.encode("utf-8"))
+
+        if from_ref is not None:
+            self._write_text(f"from {from_ref}\n")
+
+        for change in changes:
+            quoted_path = _quote_path(change.path)
+            if change.content is None:
+                self._write_text(f"D {quoted_path}\n")
+            else:
+                self._write_text(f"M 100644 inline {quoted_path}\n")
+                self._write_data(change.content)
+
+        self._write_text("\n")
+        self._commit_count += 1
+
+    @property
+    def commit_count(self) -> int:
+        return self._commit_count
+
+    def close(self, timeout: int = 3600) -> None:
+        """Flush and close the stream, waiting for `git fast-import` to finish."""
+        self._stream.close()
+        if self._process is not None:
+            returncode = self._process.wait(timeout=timeout)
+            if returncode != 0:
+                raise RuntimeError(f"git fast-import misslyckades med exit code {returncode}")

--- a/exporters/git/generate_commits.py
+++ b/exporters/git/generate_commits.py
@@ -7,50 +7,61 @@ in markdown files and creates Git commits on the appropriate dates with suitable
 """
 
 import re
+from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import List, Dict, Optional
 
-from temporal.upcoming_changes import identify_upcoming_changes
-from temporal.apply_temporal import apply_temporal, is_document_content_empty, add_empty_document_message
+from exporters.git.git_utils import create_commit_with_date, has_staged_changes, is_file_tracked, stage_file
+from formatters.format_sfs_text import clean_selex_tags
+from formatters.frontmatter_manager import (
+    extract_frontmatter_property,
+    remove_prop_from_frontmatter,
+    set_prop_in_frontmatter,
+)
+from temporal.apply_temporal import add_empty_document_message, apply_temporal, is_document_content_empty
 from temporal.title_temporal import title_temporal
-from exporters.git.git_utils import is_file_tracked, has_staged_changes, stage_file, create_commit_with_date
+from temporal.upcoming_changes import identify_upcoming_changes
 from util.datetime_utils import format_datetime, format_datetime_for_git
 from util.file_utils import read_file_content, save_to_disk
-from formatters.format_sfs_text import clean_selex_tags
-from formatters.frontmatter_manager import set_prop_in_frontmatter, extract_frontmatter_property, remove_prop_from_frontmatter
 
 
-def create_init_git_commit(
-    data: dict,
-    markdown_content: str,
-    output_file: Path,
-    verbose: bool = False
-) -> str:
+@dataclass
+class InitCommitPlan:
+    """The content, path, message and date for a document's initial commit.
+
+    Pure data — computing it touches neither disk nor git, so both the
+    subprocess-based exporter (`create_init_git_commit`) and the fast-import
+    based one can share the same legal-content logic.
     """
-    Create the initial git commit for an SFS document.
-    
-    It handles creating commits for individual documents and assumes 
-    we're already in a git repository and on the correct branch.
-    
+
+    beteckning: str
+    year: str | None  # year extracted from beteckning, e.g. "2010"; used for the year subdirectory
+    content: str  # final markdown content, selex tags already cleaned
+    commit_message: str
+    commit_date: str  # ISO date, e.g. "2010-01-15"
+
+
+def plan_init_commit(data: dict, markdown_content: str, verbose: bool = False) -> InitCommitPlan:
+    """Compute the initial-commit plan for an SFS document.
+
     Args:
         data: JSON data containing document information
-        markdown_content: The markdown content to commit and save
-        output_file: Path to the output markdown file (for local reference)
+        markdown_content: The markdown content to process
         verbose: Enable verbose output
-        
+
     Returns:
-        str: The final markdown content (cleaned, without selex tags)
+        InitCommitPlan: everything needed to write and commit the document,
+        without having performed either.
     """
     # Extract document metadata
     beteckning = data.get('beteckning')
     if not beteckning:
         raise ValueError("Beteckning saknas i dokumentdata")
-    
+
     rubrik = data.get('rubrik_after_temporal', data.get('rubrik'))
     if not rubrik:
         raise ValueError("Rubrik saknas i dokumentdata")
-    
+
     # Always expect utfardad_datum to exist
     utfardad_datum = format_datetime(data.get('fulltext', {}).get('utfardadDateTime'))
     if not utfardad_datum:
@@ -80,49 +91,13 @@ def create_init_git_commit(
 
     # Remove andringsforfattningar from frontmatter in git mode
     temporal_content_clean = remove_prop_from_frontmatter(temporal_content_with_ikraft, "andringsforfattningar")
-    
-    # Prepare final content for local save (always clean selex tags in git mode)
-    final_content = clean_selex_tags(temporal_content_clean)
 
-    # Save file locally for reference
-    save_to_disk(output_file, final_content)
-    print(f"Skapade dokument: {output_file}")
+    # Prepare final content (always clean selex tags in git mode)
+    final_content = clean_selex_tags(temporal_content_clean)
 
     # Extract year from beteckning for directory structure
     year_match = re.search(r'(\d{4}):', beteckning)
-    if year_match:
-        year = year_match.group(1)
-        relative_path = Path(year) / output_file.name
-    else:
-        relative_path = Path(output_file.name)
-
-    # Create directory structure if needed
-    target_file = Path.cwd() / relative_path
-    target_file.parent.mkdir(parents=True, exist_ok=True)
-
-    # Check if file already exists in git repository
-    if target_file.exists():
-        if verbose:
-            print(f"Varning: Filen {relative_path} finns redan i git repository, skippar")
-        return final_content
-    
-    # Also check if file is already tracked by git (in case it was deleted locally)
-    if is_file_tracked(str(relative_path)):
-        if verbose:
-            print(f"Varning: Filen {relative_path} är redan spårad av git, skippar")
-        return final_content
-
-    # Write the file (use clean content without selex tags for git)
-    save_to_disk(target_file, final_content)
-
-    # Stage the file
-    if not stage_file(str(relative_path), verbose):
-        return final_content
-
-    # Check if there are any changes to commit
-    if not has_staged_changes():
-        print(f"Inga ändringar att commita för {beteckning}")
-        return final_content
+    year = year_match.group(1) if year_match else None
 
     # Prepare commit message using temporal title
     commit_message = temporal_rubrik
@@ -134,15 +109,82 @@ def create_init_git_commit(
         commit_message += (f"\n\nHar tillkommit i Svensk författningssamling "
                          f"efter dessa förarbeten: {predocs}")
 
+    return InitCommitPlan(
+        beteckning=beteckning,
+        year=year,
+        content=final_content,
+        commit_message=commit_message,
+        commit_date=utfardad_datum,
+    )
+
+
+def create_init_git_commit(
+    data: dict,
+    markdown_content: str,
+    output_file: Path,
+    verbose: bool = False
+) -> str:
+    """
+    Create the initial git commit for an SFS document.
+
+    It handles creating commits for individual documents and assumes
+    we're already in a git repository and on the correct branch.
+
+    Args:
+        data: JSON data containing document information
+        markdown_content: The markdown content to commit and save
+        output_file: Path to the output markdown file (for local reference)
+        verbose: Enable verbose output
+
+    Returns:
+        str: The final markdown content (cleaned, without selex tags)
+    """
+    plan = plan_init_commit(data, markdown_content, verbose)
+
+    # Save file locally for reference
+    save_to_disk(output_file, plan.content)
+    print(f"Skapade dokument: {output_file}")
+
+    # Use the same filename as the local reference copy, in a year subdirectory
+    relative_path = Path(plan.year) / output_file.name if plan.year else Path(output_file.name)
+
+    # Create directory structure if needed
+    target_file = Path.cwd() / relative_path
+    target_file.parent.mkdir(parents=True, exist_ok=True)
+
+    # Check if file already exists in git repository
+    if target_file.exists():
+        if verbose:
+            print(f"Varning: Filen {relative_path} finns redan i git repository, skippar")
+        return plan.content
+
+    # Also check if file is already tracked by git (in case it was deleted locally)
+    if is_file_tracked(str(relative_path)):
+        if verbose:
+            print(f"Varning: Filen {relative_path} är redan spårad av git, skippar")
+        return plan.content
+
+    # Write the file (use clean content without selex tags for git)
+    save_to_disk(target_file, plan.content)
+
+    # Stage the file
+    if not stage_file(str(relative_path), verbose):
+        return plan.content
+
+    # Check if there are any changes to commit
+    if not has_staged_changes():
+        print(f"Inga ändringar att commita för {plan.beteckning}")
+        return plan.content
+
     # Format date for git
-    commit_date = format_datetime_for_git(utfardad_datum)
+    commit_date = format_datetime_for_git(plan.commit_date)
     if not commit_date:
-        raise ValueError(f"Kunde inte formatera datum för git: {utfardad_datum}")
+        raise ValueError(f"Kunde inte formatera datum för git: {plan.commit_date}")
 
     # Create commit with specified date
-    create_commit_with_date(commit_message, commit_date, verbose)
+    create_commit_with_date(plan.commit_message, commit_date, verbose)
 
-    return final_content
+    return plan.content
 
 
 def format_section_list(sections):
@@ -179,7 +221,7 @@ def format_section_list(sections):
 
 def generate_descriptive_commit_message(
     doc_name: str,
-    changes: List[Dict]
+    changes: list[dict]
 ) -> str:
     """
     Generate a descriptive commit message based on the changes.
@@ -193,14 +235,14 @@ def generate_descriptive_commit_message(
     """
     has_ikraft = any(c['type'] == 'ikraft' for c in changes)
     has_upphor = any(c['type'] in ['upphor', 'upphor_villkor'] for c in changes)
-    
+
     # Collect sections with titles and check for article-level changes
     ikraft_sections = []
     upphor_sections = []
     upphavd_sections = []  # Sections with selex:upphavd="true"
     has_article_changes = False
     has_article_revoked = False  # Article-level active revocation
-    
+
     for change in changes:
         # Check if this is an article-level change (whole document)
         if change.get('source') == 'article_tag':
@@ -209,16 +251,16 @@ def generate_descriptive_commit_message(
             if change.get('is_revoked'):
                 has_article_revoked = True
             continue
-        
+
         section_id = change.get('section_id')
         section_title = change.get('section_title', section_id or '')
-        
+
         if not section_id:
             continue
-            
+
         # Use section title
         display_text = section_title if section_title else f"{section_id} §"
-        
+
         if change['type'] == 'ikraft':
             ikraft_sections.append(display_text)
         elif change['type'] == 'upphor':
@@ -231,29 +273,29 @@ def generate_descriptive_commit_message(
             upphor_sections.append(display_text)
         else:
             raise ValueError(f"Okänd ändringstyp '{change['type']}' för {section_id}. Kända typer: 'ikraft', 'upphor', 'upphor_villkor'")
-    
+
     # Build commit message
     if has_ikraft and has_upphor:
         # Both entry into force and expiration
         emoji = "🔄"
-        
+
         # Check if same sections are both taking effect and expiring
         ikraft_set = set(ikraft_sections)
         upphor_set = set(upphor_sections)
         updated_sections = ikraft_set & upphor_set
         only_ikraft = ikraft_set - upphor_set
         only_upphor = upphor_set - ikraft_set
-        
+
         message_parts = []
-        
+
         if updated_sections:
             sections_str = format_section_list(list(updated_sections))
             message_parts.append(f"{sections_str} uppdateras")
-        
+
         if only_ikraft:
             sections_str = format_section_list(list(only_ikraft))
             message_parts.append(f"{sections_str} träder i kraft")
-        
+
         if only_upphor:
             sections_str = format_section_list(list(only_upphor))
             # Use specific terminology if all are actively revoked
@@ -261,12 +303,12 @@ def generate_descriptive_commit_message(
                 message_parts.append(f"{sections_str} upphävs")
             else:
                 message_parts.append(f"{sections_str} upphör att gälla")
-        
+
         if message_parts:
             message = f"{emoji} {doc_name}: {', och '.join(message_parts)}"
         else:
             raise ValueError(f"Ikraft- och upphör-ändringar på samma datum, borde inte vara möjligt för {doc_name}. Kontrollera ändringarna.")
-            
+
     elif has_ikraft:
         # Entry into force
         emoji = "✅"
@@ -281,7 +323,7 @@ def generate_descriptive_commit_message(
             message = f"{emoji} {doc_name} träder i kraft"
         else:
             raise ValueError(f"Ikraft-ändringar hittades för {doc_name} men varken sections eller article-ändringar kunde identifieras")
-            
+
     else:  # has_upphor
         # Expiration
         emoji = "🚫"
@@ -311,15 +353,70 @@ def generate_descriptive_commit_message(
                 message = f"{emoji} {doc_name} upphör att gälla"
         else:
             raise ValueError(f"Upphor-ändringar hittades för {doc_name} men varken sections eller article-ändringar kunde identifieras")
-    
+
     return message
+
+
+@dataclass
+class TemporalCommitPlan:
+    """The content and message for one date's worth of temporal changes to a
+    single document. Pure data, shared by the dry-run printer, the
+    subprocess-based exporter and the fast-import based one."""
+
+    date: str  # ISO date, e.g. "2015-06-01"
+    message: str
+    content: str  # full document content after this date's changes, selex tags cleaned
+
+
+def plan_temporal_commits(
+    content: str,
+    doc_name: str,
+    rubrik: str | None,
+    changes_by_date: dict[str, list[dict]],
+) -> list[TemporalCommitPlan]:
+    """Compute one TemporalCommitPlan per date in `changes_by_date`, in date order.
+
+    A date whose temporal processing raises is skipped with a printed
+    warning (matching the historical behaviour of `generate_temporal_commits`),
+    rather than aborting the whole document.
+    """
+    plans = []
+    for date in sorted(changes_by_date.keys()):
+        date_changes = changes_by_date[date]
+
+        try:
+            # Apply temporal changes for this date (includes H1 title processing)
+            filtered_content = apply_temporal(content, date, False)
+
+            # Check if document is empty after temporal processing and add explanatory message
+            if is_document_content_empty(filtered_content):
+                filtered_content = add_empty_document_message(filtered_content, data=None, target_date=date)
+
+            # Apply temporal title processing for frontmatter rubrik if it exists
+            if rubrik:
+                temporal_rubrik = title_temporal(rubrik, date)
+                filtered_content = set_prop_in_frontmatter(filtered_content, "rubrik", temporal_rubrik)
+
+            # Remove andringsforfattningar from frontmatter in git mode
+            filtered_content = remove_prop_from_frontmatter(filtered_content, "andringsforfattningar")
+
+            # Clean selex tags for final content
+            clean_content = clean_selex_tags(filtered_content)
+        except Exception as e:
+            print(f"Fel vid tillämpning av temporal ändringar för {date}: {e}")
+            continue
+
+        message = generate_descriptive_commit_message(doc_name, date_changes)
+        plans.append(TemporalCommitPlan(date=date, message=message, content=clean_content))
+
+    return plans
 
 
 def generate_temporal_commits(
     markdown_file: Path,
-    doc_name: Optional[str] = None,
-    from_date: Optional[str] = None,
-    to_date: Optional[str] = None,
+    doc_name: str | None = None,
+    from_date: str | None = None,
+    to_date: str | None = None,
     dry_run: bool = False
 ) -> None:
     """
@@ -345,62 +442,62 @@ def generate_temporal_commits(
             datetime.strptime(from_date, '%Y-%m-%d')
         except ValueError:
             raise ValueError(f"Invalid from_date format: {from_date}. Expected YYYY-MM-DD")
-    
+
     if to_date:
         try:
             datetime.strptime(to_date, '%Y-%m-%d')
         except ValueError:
             raise ValueError(f"Invalid to_date format: {to_date}. Expected YYYY-MM-DD")
-    
+
     # Read the markdown file
     if not markdown_file.exists():
         print(f"Fel: Filen {markdown_file} finns inte")
         return
-    
+
     try:
         content = read_file_content(markdown_file)
-    except IOError as e:
+    except OSError as e:
         print(str(e))
         return
-    
+
     # Check if selex tags are present (required for temporal processing)
     if '<article' not in content:
         raise ValueError(f"Inga selex-taggar hittades i {markdown_file}. Temporal processing kräver att selex-taggar är kvar i dokumentet")
-    
+
     # Identify upcoming changes
     changes = identify_upcoming_changes(content)
-    
+
     if not changes:
         print(f"Inga temporala ändringar hittades i {markdown_file}")
         return
-    
+
     # Filter changes by date range
     filtered_changes = []
     for change in changes:
         change_date = change['date']
-        
+
         # Check if within date range
         if from_date and change_date < from_date:
             continue
         if to_date and change_date > to_date:
             continue
-            
+
         filtered_changes.append(change)
-    
+
     if not filtered_changes:
         print(f"Inga ändringar inom datumintervallet {from_date or 'början'} - {to_date or 'slut'}")
         return
-    
+
     # Extract doc_name and rubrik from frontmatter
     doc_name = extract_frontmatter_property(content, 'beteckning')
     rubrik = extract_frontmatter_property(content, 'rubrik')
-    
+
     if not doc_name:
         print(f"Varning: Ingen doc_name hittades i frontmatter för {markdown_file}")
         return
-    
+
     print(f"Använder doc_name: {doc_name}")
-    
+
     # Group changes by date
     changes_by_date = {}
     for change in filtered_changes:
@@ -408,106 +505,51 @@ def generate_temporal_commits(
         if date not in changes_by_date:
             changes_by_date[date] = []
         changes_by_date[date].append(change)
-    
+
     if dry_run:
         # Dry run mode - show what would be committed without actually committing
         print(f"\n{'='*80}")
         print(f"DRY RUN: Visar planerade commits för {markdown_file.name}")
         print(f"{'='*80}")
-        
+
         # Table headers
         print(f"{'Datum':<12} {'Meddelande':<150}")
         print(f"{'-'*12} {'-'*150}")
-        
-        for date in sorted(changes_by_date.keys()):
-            date_changes = changes_by_date[date]
-            
-            # Apply temporal changes for this date (includes H1 title processing)
-            try:
-                filtered_content = apply_temporal(content, date, dry_run)  # No verbose for dry run
 
-                # Check if document is empty after temporal processing and add explanatory message
-                if is_document_content_empty(filtered_content):
-                    filtered_content = add_empty_document_message(filtered_content, data=None, target_date=date)
+        plans = plan_temporal_commits(content, doc_name, rubrik, changes_by_date)
+        for plan in plans:
+            display_message = plan.message[:147] + "..." if len(plan.message) > 150 else plan.message
+            print(f"{plan.date:<12} {display_message:<150}")
 
-                # Apply temporal title processing for frontmatter rubrik if it exists
-                if rubrik:
-                    temporal_rubrik = title_temporal(rubrik, date)
-                    filtered_content = set_prop_in_frontmatter(filtered_content, "rubrik", temporal_rubrik)
-
-                # Remove andringsforfattningar from frontmatter in git mode
-                filtered_content = remove_prop_from_frontmatter(filtered_content, "andringsforfattningar")
-                
-                # Clean selex tags for final content
-                clean_content = clean_selex_tags(filtered_content)
-                
-                # Generate descriptive commit message
-                message = generate_descriptive_commit_message(doc_name, date_changes)
-                
-                # Truncate message if too long for table
-                display_message = message[:147] + "..." if len(message) > 150 else message
-                
-                print(f"{date:<12} {display_message:<150}")
-                
-            except Exception as e:
-                print(f"{date:<12} {'FEL: ' + str(e)[:147]:<150}")
-        
-        print(f"\nTotalt {len(changes_by_date)} commits skulle skapas.")
+        print(f"\nTotalt {len(plans)} commits skulle skapas.")
         print("Kör utan --dry-run för att utföra commits på riktigt.")
         return
-    
+
     # Normal mode - create actual commits
     original_content = content  # Store original content for restoration
-    
-    # Create commits for each date
-    for date in sorted(changes_by_date.keys()):
-        date_changes = changes_by_date[date]
-        
-        # Apply temporal changes for this date (includes H1 title processing)
-        try:
-            filtered_content = apply_temporal(content, date, False)
 
-            # Check if document is empty after temporal processing and add explanatory message
-            if is_document_content_empty(filtered_content):
-                filtered_content = add_empty_document_message(filtered_content, data=None, target_date=date)
+    plans = plan_temporal_commits(content, doc_name, rubrik, changes_by_date)
+    for plan in plans:
+        # Write the file (use clean content without selex tags for git)
+        save_to_disk(markdown_file, plan.content)
 
-            # Apply temporal title processing for frontmatter rubrik if it exists
-            if rubrik:
-                temporal_rubrik = title_temporal(rubrik, date)
-                filtered_content = set_prop_in_frontmatter(filtered_content, "rubrik", temporal_rubrik)
-
-            # Remove andringsforfattningar from frontmatter in git mode
-            filtered_content = remove_prop_from_frontmatter(filtered_content, "andringsforfattningar")
-
-            # Clean selex tags before committing to git
-            clean_content = clean_selex_tags(filtered_content)
-            
-            # Write the file (use clean content without selex tags for git)
-            save_to_disk(markdown_file, clean_content)
-        except Exception as e:
-            print(f"Fel vid tillämpning av temporal ändringar för {date}: {e}")
-            continue
-        
-        # Generate descriptive commit message
-        message = generate_descriptive_commit_message(doc_name, date_changes)
-        
         # Stage the file
         if not stage_file(str(markdown_file)):
             continue
-        
+
         # Check if there are any changes to commit
         if not has_staged_changes():
-            print(f"Inga ändringar att committa för {date}")
+            print(f"Inga ändringar att committa för {plan.date}")
             continue
-        
-        # Create commit with the appropriate date
-        git_date = format_datetime_for_git(date)
-        if not git_date:
-            raise ValueError(f"Kunde inte formatera datum för git: {date}")
 
-        if not create_commit_with_date(message, git_date, verbose=True):
-            print(f"Fel vid commit för {date}")
-    
+        # Create commit with the appropriate date
+        git_date = format_datetime_for_git(plan.date)
+        if not git_date:
+            raise ValueError(f"Kunde inte formatera datum för git: {plan.date}")
+
+        if not create_commit_with_date(plan.message, git_date, verbose=True):
+            print(f"Fel vid commit för {plan.date}")
+
     # Restore original content after all commits
     try:
         save_to_disk(markdown_file, original_content)
@@ -517,8 +559,8 @@ def generate_temporal_commits(
 
 def generate_commits_for_directory(
     directory: Path,
-    from_date: Optional[str] = None,
-    to_date: Optional[str] = None,
+    from_date: str | None = None,
+    to_date: str | None = None,
     dry_run: bool = False
 ) -> None:
     """
@@ -533,23 +575,23 @@ def generate_commits_for_directory(
     if not directory.exists():
         print(f"Fel: Katalogen {directory} finns inte")
         return
-    
+
     if not directory.is_dir():
         print(f"Fel: {directory} är inte en katalog")
         return
-    
+
     # Find all markdown files
     md_files = list(directory.rglob("*.md"))
-    
+
     if not md_files:
         print(f"Inga markdown-filer hittades i {directory}")
         return
-    
+
     print(f"Bearbetar {len(md_files)} markdown-filer...")
-    
+
     for md_file in md_files:
         print(f"\nBearbetar {md_file.name}...")
-        
+
         try:
             generate_temporal_commits(md_file, None, from_date, to_date, dry_run)
         except Exception as e:
@@ -558,7 +600,7 @@ def generate_commits_for_directory(
 
 if __name__ == "__main__":
     import argparse
-    
+
     parser = argparse.ArgumentParser(
         description='Generera Git-commits baserat på temporala ändringar i svenska lagdokument.'
     )
@@ -571,7 +613,7 @@ if __name__ == "__main__":
         help='Startdatum (inklusivt) i formatet YYYY-MM-DD'
     )
     parser.add_argument(
-        '--to-date', 
+        '--to-date',
         help='Slutdatum (inklusivt) i formatet YYYY-MM-DD'
     )
     parser.add_argument(
@@ -579,11 +621,11 @@ if __name__ == "__main__":
         action='store_true',
         help='Visa planerade commits utan att utföra dem'
     )
-    
+
     args = parser.parse_args()
-    
+
     path = Path(args.path)
-    
+
     if path.is_file():
         generate_temporal_commits(path, None, args.from_date, args.to_date, args.dry_run)
     elif path.is_dir():

--- a/test/test_fast_import_export.py
+++ b/test/test_fast_import_export.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Tests for the fast-import based export orchestrator.
+
+These exercise `_init_commit_events` and `_temporal_commit_events` — the
+functions that turn source JSON / marker markdown into globally-sortable
+`CommitEvent`s — without touching git or a network. `convert_to_markdown` is
+monkeypatched since its own parsing behaviour is exercised elsewhere; here we
+only care that its output is routed into the right path/date/message.
+"""
+
+import json
+
+import pytest
+
+from exporters.git.fast_import_export import _init_commit_events, _temporal_commit_events
+
+
+def _stub_convert_to_markdown(content: str):
+    def _convert(data, fetch_predocs_from_api=False, apply_links=False):
+        return content
+
+    return _convert
+
+
+@pytest.mark.unit
+class TestInitCommitEvents:
+    def test_produces_one_event_with_expected_path_date_and_message(self, tmp_path, monkeypatch):
+        data = {
+            "beteckning": "2010:100",
+            "beteckningSortable": "2010:100",
+            "rubrik": "Test förordning",
+            "fulltext": {"utfardadDateTime": "2010-01-15"},
+        }
+        json_file = tmp_path / "sfs-2010-100.json"
+        json_file.write_text(json.dumps(data), encoding="utf-8")
+        monkeypatch.setattr(
+            "sfs_processor.convert_to_markdown", _stub_convert_to_markdown("# Test förordning\n\nInnehåll.\n")
+        )
+
+        events = _init_commit_events([json_file], output_dir=None, verbose=False)
+
+        assert len(events) == 1
+        event = events[0]
+        assert event.date == "2010-01-15"
+        assert event.path == "2010/sfs-2010-100.md"
+        assert "Test förordning" in event.message
+        assert "Innehåll." in event.content
+
+    def test_writes_local_reference_copy_when_output_dir_given(self, tmp_path, monkeypatch):
+        data = {
+            "beteckning": "2010:100",
+            "beteckningSortable": "2010:100",
+            "rubrik": "Test förordning",
+            "fulltext": {"utfardadDateTime": "2010-01-15"},
+        }
+        json_file = tmp_path / "sfs-2010-100.json"
+        json_file.write_text(json.dumps(data), encoding="utf-8")
+        output_dir = tmp_path / "out"
+        monkeypatch.setattr(
+            "sfs_processor.convert_to_markdown", _stub_convert_to_markdown("# Test förordning\n\nInnehåll.\n")
+        )
+
+        _init_commit_events([json_file], output_dir=output_dir, verbose=False)
+
+        assert (output_dir / "2010" / "sfs-2010-100.md").exists()
+
+    def test_skips_document_missing_required_fields(self, tmp_path, monkeypatch):
+        # No 'rubrik' -> plan_init_commit raises ValueError, which is caught and skipped.
+        data = {"beteckning": "2010:100", "fulltext": {"utfardadDateTime": "2010-01-15"}}
+        json_file = tmp_path / "broken.json"
+        json_file.write_text(json.dumps(data), encoding="utf-8")
+        monkeypatch.setattr("sfs_processor.convert_to_markdown", _stub_convert_to_markdown("# X\n\nY\n"))
+
+        events = _init_commit_events([json_file], output_dir=None, verbose=False)
+
+        assert events == []
+
+    def test_skips_unparsable_json_file(self, tmp_path):
+        json_file = tmp_path / "not-json.json"
+        json_file.write_text("{not valid json", encoding="utf-8")
+
+        events = _init_commit_events([json_file], output_dir=None, verbose=False)
+
+        assert events == []
+
+
+def _marker_document(*sections: str) -> str:
+    body = "\n\n".join(sections)
+    return f"""---
+beteckning: "2010:100"
+rubrik: Test förordning
+---
+
+<article>
+
+{body}
+
+</article>
+"""
+
+
+@pytest.mark.unit
+class TestTemporalCommitEvents:
+    def test_produces_one_event_per_change_date(self, tmp_path):
+        year_dir = tmp_path / "2010"
+        year_dir.mkdir()
+        md_file = year_dir / "sfs-2010-100-markers.md"
+        md_file.write_text(
+            _marker_document(
+                '<section id="1" class="paragraf" selex:ikraft_datum="2015-06-01">\n\n## 1 §\n\nInnehåll.\n\n</section>'
+            ),
+            encoding="utf-8",
+        )
+
+        events = _temporal_commit_events(tmp_path, from_date=None, to_date=None)
+
+        assert len(events) == 1
+        assert events[0].date == "2015-06-01"
+        assert events[0].path == "2010/sfs-2010-100.md"
+
+    def test_filters_out_of_range_dates(self, tmp_path):
+        year_dir = tmp_path / "2010"
+        year_dir.mkdir()
+        md_file = year_dir / "sfs-2010-100-markers.md"
+        md_file.write_text(
+            _marker_document(
+                '<section id="1" class="paragraf" selex:ikraft_datum="2010-06-01">\n\n## 1 §\n\nA.\n\n</section>',
+                '<section id="2" class="paragraf" selex:ikraft_datum="2030-06-01">\n\n## 2 §\n\nB.\n\n</section>',
+            ),
+            encoding="utf-8",
+        )
+
+        events = _temporal_commit_events(tmp_path, from_date="2020-01-01", to_date="2020-12-31")
+
+        assert events == []
+
+    def test_skips_files_without_selex_tags(self, tmp_path):
+        md_file = tmp_path / "plain.md"
+        md_file.write_text('---\nbeteckning: "2010:1"\n---\n\nNo tags here.\n', encoding="utf-8")
+
+        events = _temporal_commit_events(tmp_path, None, None)
+
+        assert events == []

--- a/test/test_fast_import_writer.py
+++ b/test/test_fast_import_writer.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Tests for the git-fast-import stream writer.
+
+These are integration tests in the literal sense of exercising a real `git`
+binary against a scratch repository in `tmp_path` — no SFS data involved,
+just verifying the fast-import stream round-trips correctly.
+"""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from exporters.git.fast_import_writer import FastImportWriter, FileChange, to_raw_git_date
+
+
+def run_git(repo_dir: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=repo_dir, capture_output=True, text=True, check=True
+    )
+    return result.stdout.strip()
+
+
+@pytest.fixture
+def empty_repo(tmp_path):
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    run_git(repo_dir, "init", "--quiet", "-b", "main")
+    run_git(repo_dir, "config", "user.email", "test@example.com")
+    run_git(repo_dir, "config", "user.name", "Test")
+    return repo_dir
+
+
+@pytest.mark.unit
+class TestToRawGitDate:
+    def test_winter_date_uses_cet_offset(self):
+        # Sweden is UTC+1 (CET) outside DST.
+        assert to_raw_git_date("2010-01-15") == "1263510000 +0100"
+
+    def test_summer_date_uses_cest_offset(self):
+        # Sweden is UTC+2 (CEST) during DST.
+        raw = to_raw_git_date("2024-07-01")
+        assert raw.endswith("+0200")
+
+    def test_explicit_time_is_respected(self):
+        midnight = to_raw_git_date("2010-01-15", "00:00:00")
+        noon = to_raw_git_date("2010-01-15", "12:00:00")
+        midnight_epoch = int(midnight.split()[0])
+        noon_epoch = int(noon.split()[0])
+        assert noon_epoch - midnight_epoch == 12 * 3600
+
+
+@pytest.mark.unit
+@pytest.mark.slow
+class TestFastImportWriterRootHistory:
+    """Building a brand new branch from nothing (no `from_ref`)."""
+
+    def test_single_commit_lands_with_content_message_and_date(self, empty_repo):
+        writer = FastImportWriter.to_repo(empty_repo)
+        writer.commit(
+            branch="export",
+            message="Initial SFS document",
+            author_date=to_raw_git_date("2010-01-15"),
+            committer_date=to_raw_git_date("2010-01-15"),
+            changes=[FileChange.write("2010/2010-100.md", "# Test\n\nInnehåll.\n")],
+        )
+        writer.close()
+
+        assert writer.commit_count == 1
+
+        log = run_git(empty_repo, "log", "refs/heads/export", "--format=%s|%ad", "--date=short")
+        assert log == "Initial SFS document|2010-01-15"
+
+        content = run_git(empty_repo, "show", "refs/heads/export:2010/2010-100.md")
+        assert content == "# Test\n\nInnehåll."
+
+    def test_sequential_commits_chain_as_parent_child(self, empty_repo):
+        writer = FastImportWriter.to_repo(empty_repo)
+        writer.commit(
+            branch="export",
+            message="v1",
+            author_date=to_raw_git_date("2010-01-15"),
+            committer_date=to_raw_git_date("2010-01-15"),
+            changes=[FileChange.write("doc.md", "version 1\n")],
+        )
+        writer.commit(
+            branch="export",
+            message="v2",
+            author_date=to_raw_git_date("2015-06-01"),
+            committer_date=to_raw_git_date("2015-06-01"),
+            changes=[FileChange.write("doc.md", "version 2\n")],
+        )
+        writer.close()
+
+        assert writer.commit_count == 2
+
+        # oldest first
+        subjects = run_git(
+            empty_repo, "log", "refs/heads/export", "--format=%s", "--reverse"
+        ).splitlines()
+        assert subjects == ["v1", "v2"]
+
+        parents = run_git(empty_repo, "log", "refs/heads/export", "--format=%P", "-1").strip()
+        assert parents  # v2 has one parent, v1's sha
+
+        content = run_git(empty_repo, "show", "refs/heads/export:doc.md")
+        assert content == "version 2"
+
+    def test_delete_removes_file_in_later_commit(self, empty_repo):
+        writer = FastImportWriter.to_repo(empty_repo)
+        writer.commit(
+            branch="export",
+            message="add",
+            author_date=to_raw_git_date("2010-01-01"),
+            committer_date=to_raw_git_date("2010-01-01"),
+            changes=[FileChange.write("doc.md", "content\n")],
+        )
+        writer.commit(
+            branch="export",
+            message="remove",
+            author_date=to_raw_git_date("2020-01-01"),
+            committer_date=to_raw_git_date("2020-01-01"),
+            changes=[FileChange.delete("doc.md")],
+        )
+        writer.close()
+
+        files = run_git(empty_repo, "ls-tree", "-r", "--name-only", "refs/heads/export")
+        assert files == ""
+
+    def test_unicode_content_round_trips(self, empty_repo):
+        writer = FastImportWriter.to_repo(empty_repo)
+        writer.commit(
+            branch="export",
+            message="Förordning träder i kraft ✅",
+            author_date=to_raw_git_date("2010-01-01"),
+            committer_date=to_raw_git_date("2010-01-01"),
+            changes=[FileChange.write("2010/åäö.md", "Författningssamling – ändrad §3.\n")],
+        )
+        writer.close()
+
+        message = run_git(empty_repo, "log", "refs/heads/export", "-1", "--format=%s")
+        assert message == "Förordning träder i kraft ✅"
+
+        content = run_git(empty_repo, "show", "refs/heads/export:2010/åäö.md")
+        assert content == "Författningssamling – ändrad §3."
+
+
+@pytest.mark.unit
+@pytest.mark.slow
+class TestFastImportWriterFromExistingBranch:
+    """Rooting a new export branch onto an existing `main` tip via `from_ref`."""
+
+    def test_new_branch_starts_from_main_tip_and_leaves_main_untouched(self, empty_repo):
+        (empty_repo / "README.md").write_text("hello\n")
+        run_git(empty_repo, "add", "README.md")
+        run_git(empty_repo, "commit", "--quiet", "-m", "initial")
+        main_tip = run_git(empty_repo, "rev-parse", "HEAD")
+
+        writer = FastImportWriter.to_repo(empty_repo)
+        writer.commit(
+            branch="export",
+            message="first export commit",
+            author_date=to_raw_git_date("2010-01-01"),
+            committer_date=to_raw_git_date("2010-01-01"),
+            changes=[FileChange.write("doc.md", "content\n")],
+            from_ref=main_tip,
+        )
+        writer.close()
+
+        # main is untouched
+        assert run_git(empty_repo, "rev-parse", "main") == main_tip
+        assert run_git(empty_repo, "ls-tree", "-r", "--name-only", "main") == "README.md"
+
+        # export branch has both README.md (inherited) and doc.md (new)
+        export_files = set(
+            run_git(empty_repo, "ls-tree", "-r", "--name-only", "refs/heads/export").splitlines()
+        )
+        assert export_files == {"README.md", "doc.md"}
+
+        parent = run_git(empty_repo, "log", "refs/heads/export", "--format=%P", "-1").strip()
+        assert parent == main_tip


### PR DESCRIPTION
## Summary

Prototype of an alternative to `batch_export_to_git.py`'s git export pipeline, using `git fast-import` instead of per-document/per-change `git add` + `git commit` subprocess calls (see ADR-003 for background on the backdated-commit approach; SFS has ~50 000 författningar, each potentially with many amendment commits).

- `exporters/git/fast_import_writer.py` — streams commits directly into a `git fast-import` process (inline blobs, backdated author/committer dates, no working tree or index touched).
- `exporters/git/fast_import_export.py` — orchestrator: builds every commit's plan up front (initial + all temporal changes, across every document), sorts them globally by date, writes them in a single fast-import pass, pushes once.
- `exporters/git/generate_commits.py` refactor — extracted `plan_init_commit()`/`plan_temporal_commits()` so the actual legal-content logic (temporal filtering, title processing, commit message wording) is shared between the existing subprocess-based exporter and this new one, instead of duplicated. No behavior change.

Side effect: because commits are globally date-sorted before being written, the branch's parent chain now matches real chronological order across documents, rather than being grouped document-by-document with backdated timestamps layered on top (as today's exporter produces).

**Not done:** not wired into `batch_export_to_git.py`'s CLI, not run against real SFS data or the `se-lex/sfs` remote, no throughput benchmark yet vs. the current exporter. ADR-003 intentionally left untouched until this is validated for real and a decision is made to adopt it.

## Test plan

- [x] `python -m pytest test/ -v` — all 386 tests pass, including new `test/test_fast_import_writer.py` (round-trips commits through a real `git fast-import` against scratch repos: dates/timezones, message/content, parent chaining, deletes, unicode, rooting a new branch onto an existing tip) and `test/test_fast_import_export.py` (JSON/marker-markdown → CommitEvent routing)
- [x] `ruff check` / `ruff format` clean on all touched/new files
- [ ] Run against a real (non-production) target repo clone to sanity-check output before considering adoption
- [ ] Benchmark against `batch_export_to_git.py` on realistic volume

🤖 Generated with [Claude Code](https://claude.com/claude-code)